### PR TITLE
kRPC v0.4.4 updates

### DIFF
--- a/documentation/drawing.md
+++ b/documentation/drawing.md
@@ -5,7 +5,7 @@
 ## Drawing
 
 Provides functionality for drawing objects in the flight scene.
-For drawing and interacting with the user interface, see the UI service.
+ For drawing and interacting with the user interface, see the UI service.
 
 Returns **void** 
 
@@ -19,7 +19,7 @@ Draw a line in the scene.
 
 -   `start` **{number, number, number}** Position of the start of the line.
 -   `end` **{number, number, number}** Position of the end of the line.
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 -   `visible` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether the line is visible.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -33,7 +33,7 @@ Draw a direction vector in the scene, from the center of mass of the active vess
 **Parameters**
 
 -   `direction` **{number, number, number}** Direction to draw the line in.
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 -   `length` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The length of the line.
 -   `visible` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether the line is visible.
 
@@ -48,7 +48,7 @@ Draw a polygon in the scene, defined by a list of vertices.
 **Parameters**
 
 -   `vertices` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;{number, number, number}>** Vertices of the polygon.
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 -   `visible` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether the polygon is visible.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -62,7 +62,7 @@ Draw text in the scene.
 **Parameters**
 
 -   `text` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The string to draw.
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 -   `position` **{number, number, number}** Position of the text.
 -   `rotation` **{number, number, number, number}** Rotation of the text, as a quaternion.
 -   `visible` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether the text is visible.
@@ -89,7 +89,7 @@ Remove the object.
 
 **Parameters**
 
--   `line` **Long** A long value representing the id for the Drawing.Line see [Long.js]<https://www.npmjs.com/package/long>
+-   `line` **Long** A long value representing the id for the Drawing.Line
 
 Returns **void** 
 
@@ -101,7 +101,7 @@ Start position of the line.
 
 **Parameters**
 
--   `line` **Long** A long value representing the id for the Drawing.Line see [Long.js]<https://www.npmjs.com/package/long>
+-   `line` **Long** A long value representing the id for the Drawing.Line
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -113,7 +113,7 @@ Start position of the line.
 
 **Parameters**
 
--   `line` **Long** A long value representing the id for the Drawing.Line see [Long.js]<https://www.npmjs.com/package/long>
+-   `line` **Long** A long value representing the id for the Drawing.Line
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -126,7 +126,7 @@ End position of the line.
 
 **Parameters**
 
--   `line` **Long** A long value representing the id for the Drawing.Line see [Long.js]<https://www.npmjs.com/package/long>
+-   `line` **Long** A long value representing the id for the Drawing.Line
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -138,7 +138,7 @@ End position of the line.
 
 **Parameters**
 
--   `line` **Long** A long value representing the id for the Drawing.Line see [Long.js]<https://www.npmjs.com/package/long>
+-   `line` **Long** A long value representing the id for the Drawing.Line
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -151,7 +151,7 @@ Set the color
 
 **Parameters**
 
--   `line` **Long** A long value representing the id for the Drawing.Line see [Long.js]<https://www.npmjs.com/package/long>
+-   `line` **Long** A long value representing the id for the Drawing.Line
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -163,7 +163,7 @@ Set the color
 
 **Parameters**
 
--   `line` **Long** A long value representing the id for the Drawing.Line see [Long.js]<https://www.npmjs.com/package/long>
+-   `line` **Long** A long value representing the id for the Drawing.Line
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -176,7 +176,7 @@ Set the thickness
 
 **Parameters**
 
--   `line` **Long** A long value representing the id for the Drawing.Line see [Long.js]<https://www.npmjs.com/package/long>
+-   `line` **Long** A long value representing the id for the Drawing.Line
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -188,7 +188,7 @@ Set the thickness
 
 **Parameters**
 
--   `line` **Long** A long value representing the id for the Drawing.Line see [Long.js]<https://www.npmjs.com/package/long>
+-   `line` **Long** A long value representing the id for the Drawing.Line
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -201,7 +201,7 @@ Reference frame for the positions of the object.
 
 **Parameters**
 
--   `line` **Long** A long value representing the id for the Drawing.Line see [Long.js]<https://www.npmjs.com/package/long>
+-   `line` **Long** A long value representing the id for the Drawing.Line
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -213,8 +213,8 @@ Reference frame for the positions of the object.
 
 **Parameters**
 
--   `line` **Long** A long value representing the id for the Drawing.Line see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `line` **Long** A long value representing the id for the Drawing.Line
+-   `value` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **void** 
 
@@ -226,7 +226,7 @@ Whether the object is visible.
 
 **Parameters**
 
--   `line` **Long** A long value representing the id for the Drawing.Line see [Long.js]<https://www.npmjs.com/package/long>
+-   `line` **Long** A long value representing the id for the Drawing.Line
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -238,7 +238,7 @@ Whether the object is visible.
 
 **Parameters**
 
--   `line` **Long** A long value representing the id for the Drawing.Line see [Long.js]<https://www.npmjs.com/package/long>
+-   `line` **Long** A long value representing the id for the Drawing.Line
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -252,7 +252,7 @@ Creates the material from a shader with the given name.
 
 **Parameters**
 
--   `line` **Long** A long value representing the id for the Drawing.Line see [Long.js]<https://www.npmjs.com/package/long>
+-   `line` **Long** A long value representing the id for the Drawing.Line
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -265,7 +265,7 @@ Creates the material from a shader with the given name.
 
 **Parameters**
 
--   `line` **Long** A long value representing the id for the Drawing.Line see [Long.js]<https://www.npmjs.com/package/long>
+-   `line` **Long** A long value representing the id for the Drawing.Line
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -278,7 +278,7 @@ Remove the object.
 
 **Parameters**
 
--   `polygon` **Long** A long value representing the id for the Drawing.Polygon see [Long.js]<https://www.npmjs.com/package/long>
+-   `polygon` **Long** A long value representing the id for the Drawing.Polygon
 
 Returns **void** 
 
@@ -290,7 +290,7 @@ Vertices for the polygon.
 
 **Parameters**
 
--   `polygon` **Long** A long value representing the id for the Drawing.Polygon see [Long.js]<https://www.npmjs.com/package/long>
+-   `polygon` **Long** A long value representing the id for the Drawing.Polygon
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -302,7 +302,7 @@ Vertices for the polygon.
 
 **Parameters**
 
--   `polygon` **Long** A long value representing the id for the Drawing.Polygon see [Long.js]<https://www.npmjs.com/package/long>
+-   `polygon` **Long** A long value representing the id for the Drawing.Polygon
 -   `value` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;{number, number, number}>** 
 
 Returns **void** 
@@ -315,7 +315,7 @@ Set the color
 
 **Parameters**
 
--   `polygon` **Long** A long value representing the id for the Drawing.Polygon see [Long.js]<https://www.npmjs.com/package/long>
+-   `polygon` **Long** A long value representing the id for the Drawing.Polygon
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -327,7 +327,7 @@ Set the color
 
 **Parameters**
 
--   `polygon` **Long** A long value representing the id for the Drawing.Polygon see [Long.js]<https://www.npmjs.com/package/long>
+-   `polygon` **Long** A long value representing the id for the Drawing.Polygon
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -340,7 +340,7 @@ Set the thickness
 
 **Parameters**
 
--   `polygon` **Long** A long value representing the id for the Drawing.Polygon see [Long.js]<https://www.npmjs.com/package/long>
+-   `polygon` **Long** A long value representing the id for the Drawing.Polygon
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -352,7 +352,7 @@ Set the thickness
 
 **Parameters**
 
--   `polygon` **Long** A long value representing the id for the Drawing.Polygon see [Long.js]<https://www.npmjs.com/package/long>
+-   `polygon` **Long** A long value representing the id for the Drawing.Polygon
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -365,7 +365,7 @@ Reference frame for the positions of the object.
 
 **Parameters**
 
--   `polygon` **Long** A long value representing the id for the Drawing.Polygon see [Long.js]<https://www.npmjs.com/package/long>
+-   `polygon` **Long** A long value representing the id for the Drawing.Polygon
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -377,8 +377,8 @@ Reference frame for the positions of the object.
 
 **Parameters**
 
--   `polygon` **Long** A long value representing the id for the Drawing.Polygon see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `polygon` **Long** A long value representing the id for the Drawing.Polygon
+-   `value` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **void** 
 
@@ -390,7 +390,7 @@ Whether the object is visible.
 
 **Parameters**
 
--   `polygon` **Long** A long value representing the id for the Drawing.Polygon see [Long.js]<https://www.npmjs.com/package/long>
+-   `polygon` **Long** A long value representing the id for the Drawing.Polygon
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -402,7 +402,7 @@ Whether the object is visible.
 
 **Parameters**
 
--   `polygon` **Long** A long value representing the id for the Drawing.Polygon see [Long.js]<https://www.npmjs.com/package/long>
+-   `polygon` **Long** A long value representing the id for the Drawing.Polygon
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -416,7 +416,7 @@ Creates the material from a shader with the given name.
 
 **Parameters**
 
--   `polygon` **Long** A long value representing the id for the Drawing.Polygon see [Long.js]<https://www.npmjs.com/package/long>
+-   `polygon` **Long** A long value representing the id for the Drawing.Polygon
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -429,10 +429,18 @@ Creates the material from a shader with the given name.
 
 **Parameters**
 
--   `polygon` **Long** A long value representing the id for the Drawing.Polygon see [Long.js]<https://www.npmjs.com/package/long>
+-   `polygon` **Long** A long value representing the id for the Drawing.Polygon
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
+
+## textStaticAvailableFonts
+
+**Extends Drawing**
+
+A list of all available fonts.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
 ## textRemove
 
@@ -442,7 +450,7 @@ Remove the object.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 
 Returns **void** 
 
@@ -454,7 +462,7 @@ Position of the text.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -466,7 +474,7 @@ Position of the text.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -479,7 +487,7 @@ Rotation of the text as a quaternion.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -491,22 +499,10 @@ Rotation of the text as a quaternion.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 -   `value` **{number, number, number, number}** 
 
 Returns **void** 
-
-## textGetAvailableFonts
-
-**Extends Drawing**
-
-A list of all available fonts.
-
-**Parameters**
-
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
-
-Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
 ## textGetContent
 
@@ -516,7 +512,7 @@ The text string
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -528,7 +524,7 @@ The text string
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -541,7 +537,7 @@ Name of the font
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -553,7 +549,7 @@ Name of the font
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -566,7 +562,7 @@ Font size.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -578,7 +574,7 @@ Font size.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -591,7 +587,7 @@ Character size.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -603,7 +599,7 @@ Character size.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -616,7 +612,7 @@ Font style.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -628,8 +624,8 @@ Font style.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the UI.FontStyle see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
+-   `value` **Long** A long value representing the id for the UI.FontStyle
 
 Returns **void** 
 
@@ -641,7 +637,7 @@ Alignment.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -653,8 +649,8 @@ Alignment.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the UI.TextAlignment see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
+-   `value` **Long** A long value representing the id for the UI.TextAlignment
 
 Returns **void** 
 
@@ -666,7 +662,7 @@ Line spacing.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -678,7 +674,7 @@ Line spacing.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -691,7 +687,7 @@ Anchor.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -703,8 +699,8 @@ Anchor.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the UI.TextAnchor see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
+-   `value` **Long** A long value representing the id for the UI.TextAnchor
 
 Returns **void** 
 
@@ -716,7 +712,7 @@ Set the color
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -728,7 +724,7 @@ Set the color
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -741,7 +737,7 @@ Reference frame for the positions of the object.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -753,8 +749,8 @@ Reference frame for the positions of the object.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
+-   `value` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **void** 
 
@@ -766,7 +762,7 @@ Whether the object is visible.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -778,7 +774,7 @@ Whether the object is visible.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -792,7 +788,7 @@ Creates the material from a shader with the given name.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -805,7 +801,7 @@ Creates the material from a shader with the given name.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the Drawing.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the Drawing.Text
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 

--- a/documentation/infernal-robotics.md
+++ b/documentation/infernal-robotics.md
@@ -4,7 +4,8 @@
 
 ## InfernalRobotics
 
-This service provides functionality to interact with <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/104535-105-magic-smoke-industries-infernal-robotics-0214/">Infernal Robotics</a>.
+This service provides functionality to interact with
+<a href="https://forum.kerbalspaceprogram.com/index.php?/topic/104535-112-magic-smoke-industries-infernal-robotics-202/">Infernal Robotics</a>.
 
 Returns **void** 
 
@@ -12,11 +13,11 @@ Returns **void**
 
 **Extends InfernalRobotics**
 
-A list of all the servo groups in the given &lt;paramref name="vessel}.
+A list of all the servo groups in the given {vessel}.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -24,12 +25,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends InfernalRobotics**
 
-Returns the servo group in the given &lt;paramref name="vessel} with the given &lt;paramref name="name},
-or <c>null</c> if none exists. If multiple servo groups have the same name, only one of them is returned.
+Returns the servo group in the given {vessel} with the given {name},
+or null if none exists. If multiple servo groups have the same name, only one of them is returned.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 -   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of servo group to find.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -38,13 +39,21 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends InfernalRobotics**
 
-Returns the servo in the given &lt;paramref name="vessel} with the given &lt;paramref name="name} or
-<c>null</c> if none exists. If multiple servos have the same name, only one of them is returned.
+Returns the servo in the given {vessel} with the given {name} or
+null if none exists. If multiple servos have the same name, only one of them is returned.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 -   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the servo to find.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## getAvailable
+
+**Extends InfernalRobotics**
+
+Whether Infernal Robotics is installed.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -56,7 +65,7 @@ Moves the servo to the right.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **void** 
 
@@ -68,7 +77,7 @@ Moves the servo to the left.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **void** 
 
@@ -80,7 +89,7 @@ Moves the servo to the center.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **void** 
 
@@ -92,7 +101,7 @@ Moves the servo to the next preset.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **void** 
 
@@ -104,7 +113,7 @@ Moves the servo to the previous preset.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **void** 
 
@@ -112,12 +121,12 @@ Returns **void**
 
 **Extends InfernalRobotics**
 
-Moves the servo to &lt;paramref name="position} and sets the
-speed multiplier to &lt;paramref name="speed}.
+Moves the servo to {position} and sets the
+speed multiplier to {speed}.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 -   `position` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The position to move the servo to.
 -   `speed` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Speed multiplier for the movement.
 
@@ -131,7 +140,7 @@ Stops the servo.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **void** 
 
@@ -143,7 +152,7 @@ The name of the servo.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -155,7 +164,7 @@ The name of the servo.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -168,7 +177,7 @@ The part containing the servo.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -180,7 +189,7 @@ Whether the servo should be highlighted in-game.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -193,7 +202,7 @@ The position of the servo.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -205,7 +214,7 @@ The minimum position of the servo, specified by the part configuration.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -217,7 +226,7 @@ The maximum position of the servo, specified by the part configuration.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -229,7 +238,7 @@ The minimum position of the servo, specified by the in-game tweak menu.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -241,7 +250,7 @@ The minimum position of the servo, specified by the in-game tweak menu.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -254,7 +263,7 @@ The maximum position of the servo, specified by the in-game tweak menu.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -266,7 +275,7 @@ The maximum position of the servo, specified by the in-game tweak menu.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -279,7 +288,7 @@ The speed multiplier of the servo, specified by the part configuration.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -291,7 +300,7 @@ The speed multiplier of the servo, specified by the in-game tweak menu.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -303,7 +312,7 @@ The speed multiplier of the servo, specified by the in-game tweak menu.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -316,7 +325,7 @@ The current speed at which the servo is moving.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -328,7 +337,7 @@ The current speed at which the servo is moving.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -341,7 +350,7 @@ The current speed multiplier set in the UI.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -353,7 +362,7 @@ The current speed multiplier set in the UI.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -366,7 +375,7 @@ Whether the servo is moving.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -378,7 +387,7 @@ Whether the servo is freely moving.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -390,7 +399,7 @@ Whether the servo is locked.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -402,7 +411,7 @@ Whether the servo is locked.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -415,7 +424,7 @@ Whether the servos axis is inverted.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -427,7 +436,7 @@ Whether the servos axis is inverted.
 
 **Parameters**
 
--   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo see [Long.js]<https://www.npmjs.com/package/long>
+-   `servo` **Long** A long value representing the id for the InfernalRobotics.Servo
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -436,12 +445,12 @@ Returns **void**
 
 **Extends InfernalRobotics**
 
-Returns the servo with the given &lt;paramref name="name} from this group,
-or <c>null</c> if none exists.
+Returns the servo with the given {name} from this group,
+or null if none exists.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 -   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of servo to find.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -454,7 +463,7 @@ Moves all of the servos in the group to the right.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 
 Returns **void** 
 
@@ -466,7 +475,7 @@ Moves all of the servos in the group to the left.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 
 Returns **void** 
 
@@ -478,7 +487,7 @@ Moves all of the servos in the group to the center.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 
 Returns **void** 
 
@@ -490,7 +499,7 @@ Moves all of the servos in the group to the next preset.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 
 Returns **void** 
 
@@ -502,7 +511,7 @@ Moves all of the servos in the group to the previous preset.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 
 Returns **void** 
 
@@ -514,7 +523,7 @@ Stops the servos in the group.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 
 Returns **void** 
 
@@ -526,7 +535,7 @@ The name of the group.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -538,7 +547,7 @@ The name of the group.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -551,7 +560,7 @@ The key assigned to be the "forward" key for the group.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -563,7 +572,7 @@ The key assigned to be the "forward" key for the group.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -576,7 +585,7 @@ The key assigned to be the "reverse" key for the group.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -588,7 +597,7 @@ The key assigned to be the "reverse" key for the group.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -601,7 +610,7 @@ The speed multiplier for the group.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -613,7 +622,7 @@ The speed multiplier for the group.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -626,7 +635,7 @@ Whether the group is expanded in the InfernalRobotics UI.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -638,7 +647,7 @@ Whether the group is expanded in the InfernalRobotics UI.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -651,7 +660,7 @@ The servos that are in the group.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -663,6 +672,6 @@ The parts containing the servos in the group.
 
 **Parameters**
 
--   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup see [Long.js]<https://www.npmjs.com/package/long>
+-   `servoGroup` **Long** A long value representing the id for the InfernalRobotics.ServoGroup
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 

--- a/documentation/kerbal-alarm-clock.md
+++ b/documentation/kerbal-alarm-clock.md
@@ -4,7 +4,8 @@
 
 ## KerbalAlarmClock
 
-This service provides functionality to interact with <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/22809-10x-kerbal-alarm-clock-v3500-dec-3/">Kerbal Alarm Clock</a>.
+This service provides functionality to interact with
+<a href="https://forum.kerbalspaceprogram.com/index.php?/topic/22809-13x-kerbal-alarm-clock-v3850-may-30/">Kerbal Alarm Clock</a>.
 
 Returns **void** 
 
@@ -12,7 +13,7 @@ Returns **void**
 
 **Extends KerbalAlarmClock**
 
-Get the alarm with the given &lt;paramref name="name}, or <c>null</c>
+Get the alarm with the given {name}, or null
 if no alarms have that name. If more than one alarm has the name,
 only returns one of them.
 
@@ -26,11 +27,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends KerbalAlarmClock**
 
-Get a list of alarms of the specified &lt;paramref name="type}.
+Get a list of alarms of the specified {type}.
 
 **Parameters**
 
--   `type` **Long** A long value representing the id for the KerbalAlarmClock.AlarmType see [Long.js]<https://www.npmjs.com/package/long>
+-   `type` **Long** A long value representing the id for the KerbalAlarmClock.AlarmType
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -42,9 +43,17 @@ Create a new alarm and return it.
 
 **Parameters**
 
--   `type` **Long** A long value representing the id for the KerbalAlarmClock.AlarmType see [Long.js]<https://www.npmjs.com/package/long>
+-   `type` **Long** A long value representing the id for the KerbalAlarmClock.AlarmType
 -   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the new alarm.
 -   `ut` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Time at which the new alarm should trigger.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## getAvailable
+
+**Extends KerbalAlarmClock**
+
+Whether Kerbal Alarm Clock is available.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -64,7 +73,7 @@ Removes the alarm.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 
 Returns **void** 
 
@@ -76,7 +85,7 @@ The action that the alarm triggers.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -88,8 +97,8 @@ The action that the alarm triggers.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the KerbalAlarmClock.AlarmAction see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
+-   `value` **Long** A long value representing the id for the KerbalAlarmClock.AlarmAction
 
 Returns **void** 
 
@@ -101,7 +110,7 @@ The number of seconds before the event that the alarm will fire.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -113,7 +122,7 @@ The number of seconds before the event that the alarm will fire.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -126,7 +135,7 @@ The time at which the alarm will fire.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -138,7 +147,7 @@ The time at which the alarm will fire.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -151,7 +160,7 @@ The type of the alarm.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -163,7 +172,7 @@ The unique identifier for the alarm.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -175,7 +184,7 @@ The short name of the alarm.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -187,7 +196,7 @@ The short name of the alarm.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -200,7 +209,7 @@ The long description of the alarm.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -212,7 +221,7 @@ The long description of the alarm.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -225,7 +234,7 @@ The number of seconds until the alarm will fire.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -237,7 +246,7 @@ Whether the alarm will be repeated after it has fired.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -249,7 +258,7 @@ Whether the alarm will be repeated after it has fired.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -262,7 +271,7 @@ The time delay to automatically create an alarm after it has fired.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -274,7 +283,7 @@ The time delay to automatically create an alarm after it has fired.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -287,7 +296,7 @@ The vessel that the alarm is attached to.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -299,8 +308,8 @@ The vessel that the alarm is attached to.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
+-   `value` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **void** 
 
@@ -312,7 +321,7 @@ The celestial body the vessel is departing from.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -324,8 +333,8 @@ The celestial body the vessel is departing from.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
+-   `value` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **void** 
 
@@ -337,7 +346,7 @@ The celestial body the vessel is arriving at.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -349,7 +358,7 @@ The celestial body the vessel is arriving at.
 
 **Parameters**
 
--   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `alarm` **Long** A long value representing the id for the KerbalAlarmClock.Alarm
+-   `value` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **void** 

--- a/documentation/krpc.md
+++ b/documentation/krpc.md
@@ -8,6 +8,23 @@ Main kRPC service, used by clients to interact with basic server functionality.
 
 Returns **void** 
 
+## getClientId
+
+**Extends KRPC**
+
+Returns the identifier for the current client.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## getClientName
+
+**Extends KRPC**
+
+Returns the name of the current client.
+This is an empty string if the client has no name.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
 ## getStatus
 
 **Extends KRPC**
@@ -34,8 +51,34 @@ Add a streaming request and return its identifier.
 **Parameters**
 
 -   `call` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `start` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## startStream
+
+**Extends KRPC**
+
+Start a previously added streaming request.
+
+**Parameters**
+
+-   `id` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+Returns **void** 
+
+## setStreamRate
+
+**Extends KRPC**
+
+Set the update rate for a stream in Hz.
+
+**Parameters**
+
+-   `id` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+-   `rate` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+Returns **void** 
 
 ## removeStream
 
@@ -48,6 +91,18 @@ Remove a streaming request.
 -   `id` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
+
+## addEvent
+
+**Extends KRPC**
+
+Create an event from a server side expression.
+
+**Parameters**
+
+-   `expression` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
 ## getClients
 
@@ -63,5 +118,717 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends KRPC**
 
 Get the current game scene.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## getPaused
+
+**Extends KRPC**
+
+Whether the game is paused.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## setPaused
+
+**Extends KRPC**
+
+Whether the game is paused.
+
+**Parameters**
+
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## expressionStaticConstantDouble
+
+**Extends KRPC**
+
+A constant value of double precision floating point type.
+
+**Parameters**
+
+-   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticConstantFloat
+
+**Extends KRPC**
+
+A constant value of single precision floating point type.
+
+**Parameters**
+
+-   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticConstantInt
+
+**Extends KRPC**
+
+A constant value of integer type.
+
+**Parameters**
+
+-   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticConstantBool
+
+**Extends KRPC**
+
+A constant value of boolean type.
+
+**Parameters**
+
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticConstantString
+
+**Extends KRPC**
+
+A constant value of string type.
+
+**Parameters**
+
+-   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticCall
+
+**Extends KRPC**
+
+An RPC call.
+
+**Parameters**
+
+-   `call` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticEqual
+
+**Extends KRPC**
+
+Equality comparison.
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticNotEqual
+
+**Extends KRPC**
+
+Inequality comparison.
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticGreaterThan
+
+**Extends KRPC**
+
+Greater than numerical comparison.
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticGreaterThanOrEqual
+
+**Extends KRPC**
+
+Greater than or equal numerical comparison.
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticLessThan
+
+**Extends KRPC**
+
+Less than numerical comparison.
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticLessThanOrEqual
+
+**Extends KRPC**
+
+Less than or equal numerical comparison.
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticAnd
+
+**Extends KRPC**
+
+Boolean and operator.
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticOr
+
+**Extends KRPC**
+
+Boolean or operator.
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticExclusiveOr
+
+**Extends KRPC**
+
+Boolean exclusive-or operator.
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticNot
+
+**Extends KRPC**
+
+Boolean negation operator.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticAdd
+
+**Extends KRPC**
+
+Numerical addition.
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticSubtract
+
+**Extends KRPC**
+
+Numerical subtraction.
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticMultiply
+
+**Extends KRPC**
+
+Numerical multiplication.
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticDivide
+
+**Extends KRPC**
+
+Numerical division.
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticModulo
+
+**Extends KRPC**
+
+Numerical modulo operator.
+
+Returns: The remainder of arg0 divided by arg1
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticPower
+
+**Extends KRPC**
+
+Numerical power operator.
+
+Returns: arg0 raised to the power of arg1, with type of arg0
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticLeftShift
+
+**Extends KRPC**
+
+Bitwise left shift.
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticRightShift
+
+**Extends KRPC**
+
+Bitwise right shift.
+
+**Parameters**
+
+-   `arg0` **Long** A long value representing the id for the KRPC.Expression
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticCast
+
+**Extends KRPC**
+
+Perform a cast to the given type.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+-   `type` **Long** A long value representing the id for the KRPC.Type
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticParameter
+
+**Extends KRPC**
+
+A named parameter of type double.
+Returns: A named parameter.
+
+**Parameters**
+
+-   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of the parameter.
+-   `type` **Long** A long value representing the id for the KRPC.Type
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticFunction
+
+**Extends KRPC**
+
+A function.
+Returns: A function.
+
+**Parameters**
+
+-   `parameters` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Long>** A list of long values representing the ids for the KRPC.Expression
+-   `body` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticInvoke
+
+**Extends KRPC**
+
+A function call.
+Returns: A function call.
+
+**Parameters**
+
+-   `function_` **Long** A long value representing the id for the KRPC.Expression
+-   `args`  
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticCreateTuple
+
+**Extends KRPC**
+
+Construct a tuple.
+Returns: The tuple.
+
+**Parameters**
+
+-   `elements` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Long>** A list of long values representing the ids for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticCreateList
+
+**Extends KRPC**
+
+Construct a list.
+Returns: The list.
+
+**Parameters**
+
+-   `values` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Long>** A list of long values representing the ids for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticCreateSet
+
+**Extends KRPC**
+
+Construct a set.
+Returns: The set.
+
+**Parameters**
+
+-   `values` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Long>** The values. Should all be of the same type.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticCreateDictionary
+
+**Extends KRPC**
+
+Construct a dictionary, from a list of corresponding keys and values.
+Returns: The dictionary.
+
+**Parameters**
+
+-   `keys` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Long>** A list of long values representing the ids for the KRPC.Expression
+-   `values` **[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Long>** A list of long values representing the ids for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticToList
+
+**Extends KRPC**
+
+Convert a collection to a list.
+Returns: The collection as a list.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticToSet
+
+**Extends KRPC**
+
+Convert a collection to a set.
+Returns: The collection as a set.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticGet
+
+**Extends KRPC**
+
+Access an element in a tuple, list or dictionary.
+Returns: The element.
+
+<param name="index">The index of the element to access.
+A zero indexed integer for a tuple or list, or a key for a dictionary.</param>
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+-   `index` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticCount
+
+**Extends KRPC**
+
+Number of elements in a collection.
+Returns: The number of elements in the collection.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticSum
+
+**Extends KRPC**
+
+Sum all elements of a collection.
+Returns: The sum of the elements in the collection.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticMax
+
+**Extends KRPC**
+
+Maximum of all elements in a collection.
+Returns: The maximum elements in the collection.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticMin
+
+**Extends KRPC**
+
+Minimum of all elements in a collection.
+Returns: The minimum elements in the collection.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticAverage
+
+**Extends KRPC**
+
+Minimum of all elements in a collection.
+Returns: The minimum elements in the collection.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticSelect
+
+**Extends KRPC**
+
+Run a function on every element in the collection.
+Returns: The modified collection.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+-   `func` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticWhere
+
+**Extends KRPC**
+
+Run a function on every element in the collection.
+Returns: The modified collection.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+-   `func` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticContains
+
+**Extends KRPC**
+
+Determine if a collection contains a value.
+Returns: Whether the collection contains a value.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+-   `value` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticAggregate
+
+**Extends KRPC**
+
+Applies an accumulator function over a sequence.
+Returns: The accumulated value.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+-   `func` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticAggregateWithSeed
+
+**Extends KRPC**
+
+Applies an accumulator function over a sequence, with a given seed.
+Returns: The accumulated value.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+-   `seed` **Long** A long value representing the id for the KRPC.Expression
+-   `func` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticConcat
+
+**Extends KRPC**
+
+Concatenate two sequences.
+Returns: The first sequence followed by the second sequence.
+
+**Parameters**
+
+-   `arg1` **Long** A long value representing the id for the KRPC.Expression
+-   `arg2` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticOrderBy
+
+**Extends KRPC**
+
+Order a collection using a key function.
+Returns: The ordered collection.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+-   `key` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticAll
+
+**Extends KRPC**
+
+Determine whether all items in a collection satisfy a boolean predicate.
+Returns: Whether all items satisfy the predicate.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+-   `predicate` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## expressionStaticAny
+
+**Extends KRPC**
+
+Determine whether any item in a collection satisfies a boolean predicate.
+Returns: Whether any item satisfies the predicate.
+
+**Parameters**
+
+-   `arg` **Long** A long value representing the id for the KRPC.Expression
+-   `predicate` **Long** A long value representing the id for the KRPC.Expression
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## typeStaticDouble
+
+**Extends KRPC**
+
+Double type.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## typeStaticFloat
+
+**Extends KRPC**
+
+Float type.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## typeStaticInt
+
+**Extends KRPC**
+
+Int type.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## typeStaticBool
+
+**Extends KRPC**
+
+Bool type.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## typeStaticString
+
+**Extends KRPC**
+
+String type.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 

--- a/documentation/remote-tech.md
+++ b/documentation/remote-tech.md
@@ -4,7 +4,8 @@
 
 ## RemoteTech
 
-This service provides functionality to interact with <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/75245-11-remotetech-v1610-2016-04-12/">RemoteTech</a>.
+This service provides functionality to interact with
+<a href="https://forum.kerbalspaceprogram.com/index.php?/topic/139167-13-remotetech-v188-2017-09-03/">RemoteTech</a>.
 
 Returns **void** 
 
@@ -16,7 +17,7 @@ Get a communications object, representing the communication capability of a part
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -28,7 +29,15 @@ Get the antenna object for a particular part.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## getAvailable
+
+**Extends RemoteTech**
+
+Whether RemoteTech is installed.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -48,7 +57,7 @@ Get the part containing this antenna.
 
 **Parameters**
 
--   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna see [Long.js]<https://www.npmjs.com/package/long>
+-   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -60,7 +69,7 @@ Whether the antenna has a connection.
 
 **Parameters**
 
--   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna see [Long.js]<https://www.npmjs.com/package/long>
+-   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -75,7 +84,7 @@ To set the target to a celestial body, ground station or vessel see [M:RemoteTec
 
 **Parameters**
 
--   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna see [Long.js]<https://www.npmjs.com/package/long>
+-   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -90,8 +99,8 @@ To set the target to a celestial body, ground station or vessel see [M:RemoteTec
 
 **Parameters**
 
--   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the RemoteTech.Target see [Long.js]<https://www.npmjs.com/package/long>
+-   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna
+-   `value` **Long** A long value representing the id for the RemoteTech.Target
 
 Returns **void** 
 
@@ -103,7 +112,7 @@ The celestial body the antenna is targetting.
 
 **Parameters**
 
--   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna see [Long.js]<https://www.npmjs.com/package/long>
+-   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -115,8 +124,8 @@ The celestial body the antenna is targetting.
 
 **Parameters**
 
--   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna
+-   `value` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **void** 
 
@@ -128,7 +137,7 @@ The ground station the antenna is targetting.
 
 **Parameters**
 
--   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna see [Long.js]<https://www.npmjs.com/package/long>
+-   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -140,7 +149,7 @@ The ground station the antenna is targetting.
 
 **Parameters**
 
--   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna see [Long.js]<https://www.npmjs.com/package/long>
+-   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -153,7 +162,7 @@ The vessel the antenna is targetting.
 
 **Parameters**
 
--   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna see [Long.js]<https://www.npmjs.com/package/long>
+-   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -165,8 +174,8 @@ The vessel the antenna is targetting.
 
 **Parameters**
 
--   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `antenna` **Long** A long value representing the id for the RemoteTech.Antenna
+-   `value` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **void** 
 
@@ -175,13 +184,11 @@ Returns **void**
 **Extends RemoteTech**
 
 The signal delay between the this vessel and another vessel, in seconds.
- <param name="other">
- </param>
 
 **Parameters**
 
--   `comms` **Long** A long value representing the id for the RemoteTech.Comms see [Long.js]<https://www.npmjs.com/package/long>
--   `other` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `comms` **Long** A long value representing the id for the RemoteTech.Comms
+-   `other` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -193,7 +200,7 @@ Get the vessel.
 
 **Parameters**
 
--   `comms` **Long** A long value representing the id for the RemoteTech.Comms see [Long.js]<https://www.npmjs.com/package/long>
+-   `comms` **Long** A long value representing the id for the RemoteTech.Comms
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -205,7 +212,7 @@ Whether the vessel can be controlled locally.
 
 **Parameters**
 
--   `comms` **Long** A long value representing the id for the RemoteTech.Comms see [Long.js]<https://www.npmjs.com/package/long>
+-   `comms` **Long** A long value representing the id for the RemoteTech.Comms
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -217,7 +224,7 @@ Whether the vessel has a flight computer on board.
 
 **Parameters**
 
--   `comms` **Long** A long value representing the id for the RemoteTech.Comms see [Long.js]<https://www.npmjs.com/package/long>
+-   `comms` **Long** A long value representing the id for the RemoteTech.Comms
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -229,7 +236,7 @@ Whether the vessel has any connection.
 
 **Parameters**
 
--   `comms` **Long** A long value representing the id for the RemoteTech.Comms see [Long.js]<https://www.npmjs.com/package/long>
+-   `comms` **Long** A long value representing the id for the RemoteTech.Comms
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -241,7 +248,7 @@ Whether the vessel has a connection to a ground station.
 
 **Parameters**
 
--   `comms` **Long** A long value representing the id for the RemoteTech.Comms see [Long.js]<https://www.npmjs.com/package/long>
+-   `comms` **Long** A long value representing the id for the RemoteTech.Comms
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -253,7 +260,7 @@ The shortest signal delay to the vessel, in seconds.
 
 **Parameters**
 
--   `comms` **Long** A long value representing the id for the RemoteTech.Comms see [Long.js]<https://www.npmjs.com/package/long>
+-   `comms` **Long** A long value representing the id for the RemoteTech.Comms
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -265,7 +272,7 @@ The signal delay between the vessel and the closest ground station, in seconds.
 
 **Parameters**
 
--   `comms` **Long** A long value representing the id for the RemoteTech.Comms see [Long.js]<https://www.npmjs.com/package/long>
+-   `comms` **Long** A long value representing the id for the RemoteTech.Comms
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -277,6 +284,6 @@ The antennas for this vessel.
 
 **Parameters**
 
--   `comms` **Long** A long value representing the id for the RemoteTech.Comms see [Long.js]<https://www.npmjs.com/package/long>
+-   `comms` **Long** A long value representing the id for the RemoteTech.Comms
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 

--- a/documentation/space-center.md
+++ b/documentation/space-center.md
@@ -4,7 +4,8 @@
 
 ## SpaceCenter
 
-Provides functionality to interact with Kerbal Space Program. This includes controlling the active vessel, managing its resources, planning maneuver nodes and auto-piloting.
+Provides functionality to interact with Kerbal Space Program. This includes controlling
+the active vessel, managing its resources, planning maneuver nodes and auto-piloting.
 
 Returns **void** 
 
@@ -20,11 +21,15 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-Returns a list of vessels from the given &lt;paramref name="craftDirectory} that can be launched.
+Returns a list of vessels from the given {craftDirectory}
+that can be launched.
+<param name="craftDirectory">Name of the directory in the current saves
+"Ships" directory. For example "VAB" or "SPH".</param>
 
 **Parameters**
 
--   `craftDirectory` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the directory in the current saves "Ships" directory. For example <c>"VAB"</c> or <c>"SPH"</c>.
+-   `craftDirectory` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the directory in the current saves
+    "Ships" directory. For example <c>"VAB"</c> or <c>"SPH"</c>.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -33,12 +38,23 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Launch a vessel.
+<param name="craftDirectory">Name of the directory in the current saves
+"Ships" directory, that contains the craft file.
+For example "VAB" or "SPH".</param>
+<param name="name">Name of the vessel to launch. This is the name of the ".craft" file
+in the save directory, without the ".craft" file extension.</param>
+<param name="launchSite">Name of the launch site. For example "LaunchPad" or
+"Runway".</param>
 
 **Parameters**
 
--   `craftDirectory` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the directory in the current saves "Ships" directory, that contains the craft file. For example <c>"VAB"</c> or <c>"SPH"</c>.
--   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the vessel to launch. This is the name of the ".craft" file in the save directory, without the ".craft" file extension.
--   `launchSite` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the launch site. For example <c>"LaunchPad"</c> or <c>"Runway"</c>.
+-   `craftDirectory` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the directory in the current saves
+    "Ships" directory, that contains the craft file.
+    For example <c>"VAB"</c> or <c>"SPH"</c>.
+-   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the vessel to launch. This is the name of the ".craft" file
+    in the save directory, without the ".craft" file extension.
+-   `launchSite` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the launch site. For example <c>"LaunchPad"</c> or
+    <c>"Runway"</c>.
 
 Returns **void** 
 
@@ -47,7 +63,9 @@ Returns **void**
 **Extends SpaceCenter**
 
 Launch a new vessel from the VAB onto the launchpad.
- This is equivalent to calling [M:SpaceCenter.LaunchVessel](M:SpaceCenter.LaunchVessel) with the craft directory set to "VAB" and the launch site set to "LaunchPad".
+
+ This is equivalent to calling [M:SpaceCenter.LaunchVessel](M:SpaceCenter.LaunchVessel) with the craft directory
+set to "VAB" and the launch site set to "LaunchPad".
 
 **Parameters**
 
@@ -60,7 +78,9 @@ Returns **void**
 **Extends SpaceCenter**
 
 Launch a new vessel from the SPH onto the runway.
- This is equivalent to calling [M:SpaceCenter.LaunchVessel](M:SpaceCenter.LaunchVessel) with the craft directory set to "SPH" and the launch site set to "Runway".
+
+ This is equivalent to calling [M:SpaceCenter.LaunchVessel](M:SpaceCenter.LaunchVessel) with the craft directory
+set to "SPH" and the launch site set to "Runway".
 
 **Parameters**
 
@@ -73,7 +93,8 @@ Returns **void**
 **Extends SpaceCenter**
 
 Save the game with a given name.
-This will create a save file called <c>name.sfs</c> in the folder of the current save game.
+This will create a save file called name.sfs in the folder of the
+current save game.
 
 **Parameters**
 
@@ -86,7 +107,8 @@ Returns **void**
 **Extends SpaceCenter**
 
 Load the game with the given name.
-This will create a load a save file called <c>name.sfs</c> from the folder of the current save game.
+This will create a load a save file called name.sfs from the folder of the
+current save game.
 
 **Parameters**
 
@@ -99,7 +121,7 @@ Returns **void**
 **Extends SpaceCenter**
 
 Save a quicksave.
-This is the same as calling [M:SpaceCenter.Save](M:SpaceCenter.Save) with the name "quicksave".
+ This is the same as calling [M:SpaceCenter.Save](M:SpaceCenter.Save) with the name "quicksave".
 
 Returns **void** 
 
@@ -108,7 +130,7 @@ Returns **void**
 **Extends SpaceCenter**
 
 Load a quicksave.
-This is the same as calling [M:SpaceCenter.Load](M:SpaceCenter.Load) with the name "quicksave".
+ This is the same as calling [M:SpaceCenter.Load](M:SpaceCenter.Load) with the name "quicksave".
 
 Returns **void** 
 
@@ -116,10 +138,11 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-Returns <c>true</c> if regular "on-rails" time warp can be used, at the specified warp
-&lt;paramref name="factor}. The maximum time warp rate is limited by various things,
+Returns true if regular "on-rails" time warp can be used, at the specified warp
+{factor}. The maximum time warp rate is limited by various things,
 including how close the active vessel is to a planet. See
-<a href="http://wiki.kerbalspaceprogram.com/wiki/Time_warp">the KSP wiki</a> for details.
+<a href="https://wiki.kerbalspaceprogram.com/wiki/Time_warp">the KSP wiki</a>
+for details.
 
 **Parameters**
 
@@ -132,13 +155,17 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Uses time acceleration to warp forward to a time in the future, specified
-by universal time &lt;paramref name="ut}. This call blocks until the desired
+by universal time {ut}. This call blocks until the desired
 time is reached. Uses regular "on-rails" or physical time warp as appropriate.
 For example, physical time warp is used when the active vessel is traveling
 through an atmosphere. When using regular "on-rails" time warp, the warp
-rate is limited by &lt;paramref name="maxRailsRate}, and when using physical
-time warp, the warp rate is limited by &lt;paramref name="maxPhysicsRate}.
-    <returns>When the time warp is complete.</returns>
+rate is limited by {maxRailsRate}, and when using physical
+time warp, the warp rate is limited by {maxPhysicsRate}.
+
+<param name="maxRailsRate">The maximum warp rate in regular "on-rails" time warp.
+</param>
+
+Returns: When the time warp is complete.
 
 **Parameters**
 
@@ -152,14 +179,19 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-Converts a position vector from one reference frame to another.
-    <returns>The corresponding position vector in reference frame &lt;paramref name="to}.</returns>
+Converts a position from one reference frame to another.
+<param name="position">Position, as a vector, in reference frame
+{from}.</param>
+
+Returns: The corresponding position, as a vector, in reference frame
+{to}.
 
 **Parameters**
 
--   `position` **{number, number, number}** Position vector in reference frame <paramref name="from" />.
--   `from` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
--   `to` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `position` **{number, number, number}** Position, as a vector, in reference frame
+    <paramref name="from" />.
+-   `from` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+-   `to` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -167,14 +199,19 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Converts a direction vector from one reference frame to another.
-    <returns>The corresponding direction vector in reference frame &lt;paramref name="to}.</returns>
+Converts a direction from one reference frame to another.
+<param name="direction">Direction, as a vector, in reference frame
+{from}. </param>
+
+Returns: The corresponding direction, as a vector, in reference frame
+{to}.
 
 **Parameters**
 
--   `direction` **{number, number, number}** Direction vector in reference frame <paramref name="from" />.
--   `from` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
--   `to` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `direction` **{number, number, number}** Direction, as a vector, in reference frame
+    <paramref name="from" />.
+-   `from` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+-   `to` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -183,13 +220,18 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Converts a rotation from one reference frame to another.
-    <returns>The corresponding rotation in reference frame &lt;paramref name="to}.</returns>
+<param name="rotation">Rotation, as a quaternion of the form <math>(x, y, z, w)</math>,
+in reference frame {from}.</param>
+
+Returns: The corresponding rotation, as a quaternion of the form
+<math>(x, y, z, w)</math>, in reference frame {to}.
 
 **Parameters**
 
--   `rotation` **{number, number, number, number}** Rotation in reference frame <paramref name="from" />.
--   `from` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
--   `to` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `rotation` **{number, number, number, number}** Rotation, as a quaternion of the form <math>(x, y, z, w)</math>,
+    in reference frame <paramref name="from" />.
+-   `from` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+-   `to` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -197,17 +239,61 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Converts a velocity vector (acting at the specified position vector) from one
-reference frame to another. The position vector is required to take the
-relative angular velocity of the reference frames into account.
-     <returns>The corresponding velocity in reference frame &lt;paramref name="to}.</returns>
+Converts a velocity (acting at the specified position) from one reference frame
+to another. The position is required to take the relative angular velocity of the
+reference frames into account.
+<param name="position">Position, as a vector, in reference frame
+{from}.</param>
+<param name="velocity">Velocity, as a vector that points in the direction of travel and
+whose magnitude is the speed in meters per second, in reference frame
+{from}.</param>
+
+Returns: The corresponding velocity, as a vector, in reference frame
+{to}.
 
 **Parameters**
 
--   `position` **{number, number, number}** Position vector in reference frame <paramref name="from" />.
--   `velocity` **{number, number, number}** Velocity vector in reference frame <paramref name="from" />.
--   `from` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
--   `to` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `position` **{number, number, number}** Position, as a vector, in reference frame
+    <paramref name="from" />.
+-   `velocity` **{number, number, number}** Velocity, as a vector that points in the direction of travel and
+    whose magnitude is the speed in meters per second, in reference frame
+    <paramref name="from" />.
+-   `from` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+-   `to` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## raycastDistance
+
+**Extends SpaceCenter**
+
+Cast a ray from a given position in a given direction, and return the distance to the hit point.
+If no hit occurs, returns infinity.
+
+Returns: The distance to the hit, in meters, or infinity if there was no hit.
+
+**Parameters**
+
+-   `position` **{number, number, number}** Position, as a vector, of the origin of the ray.
+-   `direction` **{number, number, number}** Direction of the ray, as a unit vector.
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## raycastPart
+
+**Extends SpaceCenter**
+
+Cast a ray from a given position in a given direction, and return the part that it hits.
+If no hit occurs, returns null.
+
+Returns: The part that was hit or null if there was no hit.
+
+**Parameters**
+
+-   `position` **{number, number, number}** Position, as a vector, of the origin of the ray.
+-   `direction` **{number, number, number}** Direction of the ray, as a unit vector.
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -227,7 +313,7 @@ The currently active vessel.
 
 **Parameters**
 
--   `value` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `value` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **void** 
 
@@ -264,7 +350,7 @@ The currently targeted celestial body.
 
 **Parameters**
 
--   `value` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `value` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **void** 
 
@@ -284,7 +370,7 @@ The currently targeted vessel.
 
 **Parameters**
 
--   `value` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `value` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **void** 
 
@@ -304,7 +390,7 @@ The currently targeted docking port.
 
 **Parameters**
 
--   `value` **Long** A long value representing the id for the SpaceCenter.DockingPort see [Long.js]<https://www.npmjs.com/package/long>
+-   `value` **Long** A long value representing the id for the SpaceCenter.DockingPort
 
 Returns **void** 
 
@@ -316,6 +402,14 @@ The waypoint manager.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
+## getContractManager
+
+**Extends SpaceCenter**
+
+The contract manager.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
 ## getCamera
 
 **Extends SpaceCenter**
@@ -323,6 +417,46 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 An object that can be used to control the camera.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## getUiVisible
+
+**Extends SpaceCenter**
+
+Whether the UI is visible.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## setUiVisible
+
+**Extends SpaceCenter**
+
+Whether the UI is visible.
+
+**Parameters**
+
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## getNavball
+
+**Extends SpaceCenter**
+
+Whether the navball is visible.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## setNavball
+
+**Extends SpaceCenter**
+
+Whether the navball is visible.
+
+**Parameters**
+
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
 
 ## getUt
 
@@ -336,8 +470,8 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The value of the <a href="https://en.wikipedia.org/wiki/Gravitational_constant">gravitational constant</a>
-G in <math>N(m/kg)^2</math>.
+The value of the <a href="https://en.wikipedia.org/wiki/Gravitational_constant">
+gravitational constant</a> G in <math>N(m/kg)^2</math>.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -381,9 +515,10 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 The time warp rate, using regular "on-rails" time warp. A value between
 0 and 7 inclusive. 0 means no time warp. Returns 0 if physical time warp
 is active.
+
 If requested time warp factor cannot be set, it will be set to the next
 lowest possible value. For example, if the vessel is too close to a
-planet. See <a href="http://wiki.kerbalspaceprogram.com/wiki/Time_warp">
+planet. See <a href="https://wiki.kerbalspaceprogram.com/wiki/Time_warp">
 the KSP wiki</a> for details.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -395,9 +530,10 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 The time warp rate, using regular "on-rails" time warp. A value between
 0 and 7 inclusive. 0 means no time warp. Returns 0 if physical time warp
 is active.
+
 If requested time warp factor cannot be set, it will be set to the next
 lowest possible value. For example, if the vessel is too close to a
-planet. See <a href="http://wiki.kerbalspaceprogram.com/wiki/Time_warp">
+planet. See <a href="https://wiki.kerbalspaceprogram.com/wiki/Time_warp">
 the KSP wiki</a> for details.
 
 **Parameters**
@@ -433,8 +569,9 @@ Returns **void**
 **Extends SpaceCenter**
 
 The current maximum regular "on-rails" warp factor that can be set.
-A value between 0 and 7 inclusive.  See
-<a href="http://wiki.kerbalspaceprogram.com/wiki/Time_warp">the KSP wiki</a> for details.
+A value between 0 and 7 inclusive. See
+<a href="https://wiki.kerbalspaceprogram.com/wiki/Time_warp">the KSP wiki</a>
+for details.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -442,7 +579,7 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Whether <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/19321-105-ferram-aerospace-research-v01557-johnson-21816/">Ferram Aerospace Research</a> is installed.
+Whether <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/19321-130-ferram-aerospace-research-v0159-liebe-82117/">Ferram Aerospace Research</a> is installed.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -454,7 +591,7 @@ Engage the auto-pilot.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **void** 
 
@@ -466,7 +603,7 @@ Disengage the auto-pilot.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **void** 
 
@@ -474,11 +611,12 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-Blocks until the vessel is pointing in the target direction and has the target roll (if set).
+Blocks until the vessel is pointing in the target direction and has
+the target roll (if set). Throws an exception if the auto-pilot has not been engaged.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **void** 
 
@@ -490,7 +628,7 @@ Set target pitch and heading angles.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 -   `pitch` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Target pitch angle, in degrees between -90° and +90°.
 -   `heading` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Target heading angle, in degrees between 0° and 360°.
 
@@ -501,12 +639,12 @@ Returns **void**
 **Extends SpaceCenter**
 
 The error, in degrees, between the direction the ship has been asked
-to point in and the direction it is pointing in. Returns zero if the auto-pilot
+to point in and the direction it is pointing in. Throws an exception if the auto-pilot
 has not been engaged and SAS is not enabled or is in stability assist mode.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -515,11 +653,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The error, in degrees, between the vessels current and target pitch.
-Returns zero if the auto-pilot has not been engaged.
+Throws an exception if the auto-pilot has not been engaged.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -528,11 +666,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The error, in degrees, between the vessels current and target heading.
-Returns zero if the auto-pilot has not been engaged.
+Throws an exception if the auto-pilot has not been engaged.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -541,11 +679,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The error, in degrees, between the vessels current and target roll.
-Returns zero if the auto-pilot has not been engaged or no target roll is set.
+Throws an exception if the auto-pilot has not been engaged or no target roll is set.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -554,12 +692,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The reference frame for the target direction ([M:SpaceCenter.AutoPilot.TargetDirection](M:SpaceCenter.AutoPilot.TargetDirection)).
-An error will be thrown if this property is set to a reference frame that rotates with the vessel being controlled,
-as it is impossible to rotate the vessel in such a reference frame.
+ An error will be thrown if this property is set to a reference frame that rotates with
+the vessel being controlled, as it is impossible to rotate the vessel in such a
+reference frame.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -568,13 +707,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The reference frame for the target direction ([M:SpaceCenter.AutoPilot.TargetDirection](M:SpaceCenter.AutoPilot.TargetDirection)).
-An error will be thrown if this property is set to a reference frame that rotates with the vessel being controlled,
-as it is impossible to rotate the vessel in such a reference frame.
+ An error will be thrown if this property is set to a reference frame that rotates with
+the vessel being controlled, as it is impossible to rotate the vessel in such a
+reference frame.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
+-   `value` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **void** 
 
@@ -586,7 +726,7 @@ The target pitch, in degrees, between -90° and +90°.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -598,7 +738,7 @@ The target pitch, in degrees, between -90° and +90°.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -611,7 +751,7 @@ The target heading, in degrees, between 0° and 360°.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -623,7 +763,7 @@ The target heading, in degrees, between 0° and 360°.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -632,11 +772,11 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-The target roll, in degrees. <c>NaN</c> if no target roll is set.
+The target roll, in degrees. NaN if no target roll is set.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -644,11 +784,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The target roll, in degrees. <c>NaN</c> if no target roll is set.
+The target roll, in degrees. NaN if no target roll is set.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -658,10 +798,11 @@ Returns **void**
 **Extends SpaceCenter**
 
 Direction vector corresponding to the target pitch and heading.
+This is in the reference frame specified by [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame).
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -670,10 +811,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Direction vector corresponding to the target pitch and heading.
+This is in the reference frame specified by [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame).
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -683,11 +825,11 @@ Returns **void**
 **Extends SpaceCenter**
 
 The state of SAS.
- <remarks>Equivalent to [M:SpaceCenter.Control.SAS](M:SpaceCenter.Control.SAS)
+<remarks>Equivalent to [M:SpaceCenter.Control.SAS](M:SpaceCenter.Control.SAS)
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -696,11 +838,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The state of SAS.
- <remarks>Equivalent to [M:SpaceCenter.Control.SAS](M:SpaceCenter.Control.SAS)
+<remarks>Equivalent to [M:SpaceCenter.Control.SAS](M:SpaceCenter.Control.SAS)
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -710,12 +852,13 @@ Returns **void**
 **Extends SpaceCenter**
 
 The current [T:SpaceCenter.SASMode](T:SpaceCenter.SASMode).
-These modes are equivalent to the mode buttons to the left of the navball that appear when SAS is enabled.
- <remarks>Equivalent to [M:SpaceCenter.Control.SASMode](M:SpaceCenter.Control.SASMode)
+These modes are equivalent to the mode buttons to the left of the navball that appear
+when SAS is enabled.
+<remarks>Equivalent to [M:SpaceCenter.Control.SASMode](M:SpaceCenter.Control.SASMode)
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -724,13 +867,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The current [T:SpaceCenter.SASMode](T:SpaceCenter.SASMode).
-These modes are equivalent to the mode buttons to the left of the navball that appear when SAS is enabled.
- <remarks>Equivalent to [M:SpaceCenter.Control.SASMode](M:SpaceCenter.Control.SASMode)
+These modes are equivalent to the mode buttons to the left of the navball that appear
+when SAS is enabled.
+<remarks>Equivalent to [M:SpaceCenter.Control.SASMode](M:SpaceCenter.Control.SASMode)
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.SASMode see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
+-   `value` **Long** A long value representing the id for the SpaceCenter.SASMode
 
 Returns **void** 
 
@@ -743,7 +887,7 @@ Defaults to 5 degrees.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -756,7 +900,7 @@ Defaults to 5 degrees.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -767,12 +911,12 @@ Returns **void**
 
 The maximum amount of time that the vessel should need to come to a complete stop.
 This determines the maximum angular velocity of the vessel.
-A vector of three stopping times, in seconds, one for each of the pitch, roll and yaw axes.
-Defaults to 0.5 seconds for each axis.
+A vector of three stopping times, in seconds, one for each of the pitch, roll
+and yaw axes. Defaults to 0.5 seconds for each axis.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -782,12 +926,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 The maximum amount of time that the vessel should need to come to a complete stop.
 This determines the maximum angular velocity of the vessel.
-A vector of three stopping times, in seconds, one for each of the pitch, roll and yaw axes.
-Defaults to 0.5 seconds for each axis.
+A vector of three stopping times, in seconds, one for each of the pitch, roll
+and yaw axes. Defaults to 0.5 seconds for each axis.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -803,7 +947,7 @@ Defaults to 5 seconds for each axis.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -818,7 +962,7 @@ Defaults to 5 seconds for each axis.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -827,14 +971,15 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-The angle at which the autopilot considers the vessel to be pointing close to the target.
+The angle at which the autopilot considers the vessel to be pointing
+close to the target.
 This determines the midpoint of the target velocity attenuation function.
 A vector of three angles, in degrees, one for each of the pitch, roll and yaw axes.
 Defaults to 1° for each axis.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -842,14 +987,15 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The angle at which the autopilot considers the vessel to be pointing close to the target.
+The angle at which the autopilot considers the vessel to be pointing
+close to the target.
 This determines the midpoint of the target velocity attenuation function.
 A vector of three angles, in degrees, one for each of the pitch, roll and yaw axes.
 Defaults to 1° for each axis.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -858,13 +1004,13 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-Whether the rotation rate controllers PID parameters should be automatically tuned using the
-vessels moment of inertia and available torque. Defaults to <c>true</c>.
-See [M:SpaceCenter.AutoPilot.TimeToPeak](M:SpaceCenter.AutoPilot.TimeToPeak) and  [M:SpaceCenter.AutoPilot.Overshoot](M:SpaceCenter.AutoPilot.Overshoot).
+Whether the rotation rate controllers PID parameters should be automatically tuned
+using the vessels moment of inertia and available torque. Defaults to true.
+See [M:SpaceCenter.AutoPilot.TimeToPeak](M:SpaceCenter.AutoPilot.TimeToPeak) and [M:SpaceCenter.AutoPilot.Overshoot](M:SpaceCenter.AutoPilot.Overshoot).
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -872,13 +1018,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Whether the rotation rate controllers PID parameters should be automatically tuned using the
-vessels moment of inertia and available torque. Defaults to <c>true</c>.
-See [M:SpaceCenter.AutoPilot.TimeToPeak](M:SpaceCenter.AutoPilot.TimeToPeak) and  [M:SpaceCenter.AutoPilot.Overshoot](M:SpaceCenter.AutoPilot.Overshoot).
+Whether the rotation rate controllers PID parameters should be automatically tuned
+using the vessels moment of inertia and available torque. Defaults to true.
+See [M:SpaceCenter.AutoPilot.TimeToPeak](M:SpaceCenter.AutoPilot.TimeToPeak) and [M:SpaceCenter.AutoPilot.Overshoot](M:SpaceCenter.AutoPilot.Overshoot).
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -893,7 +1039,7 @@ Defaults to 3 seconds for each axis.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -907,7 +1053,7 @@ Defaults to 3 seconds for each axis.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -922,7 +1068,7 @@ Defaults to 0.01 for each axis.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -936,7 +1082,7 @@ Defaults to 0.01 for each axis.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -946,11 +1092,12 @@ Returns **void**
 **Extends SpaceCenter**
 
 Gains for the pitch PID controller.
-When [M:SpaceCenter.AutoPilot.AutoTune](M:SpaceCenter.AutoPilot.AutoTune) is true, these values are updated automatically, which will overwrite any manual changes.
+ When [M:SpaceCenter.AutoPilot.AutoTune](M:SpaceCenter.AutoPilot.AutoTune) is true, these values are updated automatically,
+which will overwrite any manual changes.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -959,11 +1106,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Gains for the pitch PID controller.
-When [M:SpaceCenter.AutoPilot.AutoTune](M:SpaceCenter.AutoPilot.AutoTune) is true, these values are updated automatically, which will overwrite any manual changes.
+ When [M:SpaceCenter.AutoPilot.AutoTune](M:SpaceCenter.AutoPilot.AutoTune) is true, these values are updated automatically,
+which will overwrite any manual changes.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -973,11 +1121,12 @@ Returns **void**
 **Extends SpaceCenter**
 
 Gains for the roll PID controller.
-When [M:SpaceCenter.AutoPilot.AutoTune](M:SpaceCenter.AutoPilot.AutoTune) is true, these values are updated automatically, which will overwrite any manual changes.
+ When [M:SpaceCenter.AutoPilot.AutoTune](M:SpaceCenter.AutoPilot.AutoTune) is true, these values are updated automatically,
+which will overwrite any manual changes.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -986,11 +1135,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Gains for the roll PID controller.
-When [M:SpaceCenter.AutoPilot.AutoTune](M:SpaceCenter.AutoPilot.AutoTune) is true, these values are updated automatically, which will overwrite any manual changes.
+ When [M:SpaceCenter.AutoPilot.AutoTune](M:SpaceCenter.AutoPilot.AutoTune) is true, these values are updated automatically,
+which will overwrite any manual changes.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -1000,11 +1150,12 @@ Returns **void**
 **Extends SpaceCenter**
 
 Gains for the yaw PID controller.
-When [M:SpaceCenter.AutoPilot.AutoTune](M:SpaceCenter.AutoPilot.AutoTune) is true, these values are updated automatically, which will overwrite any manual changes.
+ When [M:SpaceCenter.AutoPilot.AutoTune](M:SpaceCenter.AutoPilot.AutoTune) is true, these values are updated automatically,
+which will overwrite any manual changes.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1013,11 +1164,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Gains for the yaw PID controller.
-When [M:SpaceCenter.AutoPilot.AutoTune](M:SpaceCenter.AutoPilot.AutoTune) is true, these values are updated automatically, which will overwrite any manual changes.
+ When [M:SpaceCenter.AutoPilot.AutoTune](M:SpaceCenter.AutoPilot.AutoTune) is true, these values are updated automatically,
+which will overwrite any manual changes.
 
 **Parameters**
 
--   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot see [Long.js]<https://www.npmjs.com/package/long>
+-   `autoPilot` **Long** A long value representing the id for the SpaceCenter.AutoPilot
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -1030,7 +1182,7 @@ The current mode of the camera.
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1042,8 +1194,8 @@ The current mode of the camera.
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.CameraMode see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
+-   `value` **Long** A long value representing the id for the SpaceCenter.CameraMode
 
 Returns **void** 
 
@@ -1056,7 +1208,7 @@ A value between [M:SpaceCenter.Camera.MinPitch](M:SpaceCenter.Camera.MinPitch) a
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1069,7 +1221,7 @@ A value between [M:SpaceCenter.Camera.MinPitch](M:SpaceCenter.Camera.MinPitch) a
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -1082,7 +1234,7 @@ The heading of the camera, in degrees.
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1094,7 +1246,7 @@ The heading of the camera, in degrees.
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -1108,7 +1260,7 @@ A value between [M:SpaceCenter.Camera.MinDistance](M:SpaceCenter.Camera.MinDista
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1121,7 +1273,7 @@ A value between [M:SpaceCenter.Camera.MinDistance](M:SpaceCenter.Camera.MinDista
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -1134,7 +1286,7 @@ The minimum pitch of the camera.
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1146,7 +1298,7 @@ The maximum pitch of the camera.
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1158,7 +1310,7 @@ Minimum distance from the camera to the subject, in meters.
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1170,7 +1322,7 @@ Maximum distance from the camera to the subject, in meters.
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1182,7 +1334,7 @@ Default distance from the camera to the subject, in meters.
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1191,12 +1343,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 In map mode, the celestial body that the camera is focussed on.
-Returns <c>null</c> if the camera is not focussed on a celestial body.
+Returns null if the camera is not focussed on a celestial body.
 Returns an error is the camera is not in map mode.
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1205,13 +1357,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 In map mode, the celestial body that the camera is focussed on.
-Returns <c>null</c> if the camera is not focussed on a celestial body.
+Returns null if the camera is not focussed on a celestial body.
 Returns an error is the camera is not in map mode.
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
+-   `value` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **void** 
 
@@ -1220,12 +1372,12 @@ Returns **void**
 **Extends SpaceCenter**
 
 In map mode, the vessel that the camera is focussed on.
-Returns <c>null</c> if the camera is not focussed on a vessel.
+Returns null if the camera is not focussed on a vessel.
 Returns an error is the camera is not in map mode.
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1234,13 +1386,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 In map mode, the vessel that the camera is focussed on.
-Returns <c>null</c> if the camera is not focussed on a vessel.
+Returns null if the camera is not focussed on a vessel.
 Returns an error is the camera is not in map mode.
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
+-   `value` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **void** 
 
@@ -1249,12 +1401,12 @@ Returns **void**
 **Extends SpaceCenter**
 
 In map mode, the maneuver node that the camera is focussed on.
-Returns <c>null</c> if the camera is not focussed on a maneuver node.
+Returns null if the camera is not focussed on a maneuver node.
 Returns an error is the camera is not in map mode.
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1263,13 +1415,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 In map mode, the maneuver node that the camera is focussed on.
-Returns <c>null</c> if the camera is not focussed on a maneuver node.
+Returns null if the camera is not focussed on a maneuver node.
 Returns an error is the camera is not in map mode.
 
 **Parameters**
 
--   `camera` **Long** A long value representing the id for the SpaceCenter.Camera see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `camera` **Long** A long value representing the id for the SpaceCenter.Camera
+-   `value` **Long** A long value representing the id for the SpaceCenter.Node
 
 Returns **void** 
 
@@ -1277,14 +1429,14 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-The height of the surface relative to mean sea level at the given position,
-in meters. When over water this is equal to 0.
+The height of the surface relative to mean sea level, in meters,
+at the given position. When over water this is equal to 0.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
--   `latitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Latitude in degrees
--   `longitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Longitude in degrees
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `latitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Latitude in degrees.
+-   `longitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Longitude in degrees.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1292,15 +1444,15 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The height of the surface relative to mean sea level at the given position,
-in meters. When over water, this is the height of the sea-bed and is therefore a
-negative value.
+The height of the surface relative to mean sea level, in meters,
+at the given position. When over water, this is the height
+of the sea-bed and is therefore  negative value.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
--   `latitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Latitude in degrees
--   `longitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Longitude in degrees
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `latitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Latitude in degrees.
+-   `longitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Longitude in degrees.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1308,14 +1460,16 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The position at mean sea level at the given latitude and longitude, in the given reference frame.
+The position at mean sea level at the given latitude and longitude,
+in the given reference frame.
+Returns: Position as a vector.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
--   `latitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Latitude in degrees
--   `longitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Longitude in degrees
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `latitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Latitude in degrees.
+-   `longitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Longitude in degrees.
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1325,13 +1479,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 The position of the surface at the given latitude and longitude, in the given
 reference frame. When over water, this is the position of the surface of the water.
+Returns: Position as a vector.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
--   `latitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Latitude in degrees
--   `longitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Longitude in degrees
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `latitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Latitude in degrees.
+-   `longitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Longitude in degrees.
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1341,13 +1496,138 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 The position of the surface at the given latitude and longitude, in the given
 reference frame. When over water, this is the position at the bottom of the sea-bed.
+Returns: Position as a vector.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
--   `latitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Latitude in degrees
--   `longitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Longitude in degrees
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `latitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Latitude in degrees.
+-   `longitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Longitude in degrees.
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## celestialBodyPositionAtAltitude
+
+**Extends SpaceCenter**
+
+The position at the given latitude, longitude and altitude, in the given reference frame.
+Returns: Position as a vector.
+
+**Parameters**
+
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `latitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Latitude in degrees.
+-   `longitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Longitude in degrees.
+-   `altitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Altitude in meters above sea level.
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## celestialBodyLatitudeAtPosition
+
+**Extends SpaceCenter**
+
+The latitude of the given position, in the given reference frame.
+
+**Parameters**
+
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `position` **{number, number, number}** Position as a vector.
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## celestialBodyLongitudeAtPosition
+
+**Extends SpaceCenter**
+
+The longitude of the given position, in the given reference frame.
+
+**Parameters**
+
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `position` **{number, number, number}** Position as a vector.
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## celestialBodyAltitudeAtPosition
+
+**Extends SpaceCenter**
+
+The altitude, in meters, of the given position in the given reference frame.
+
+**Parameters**
+
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `position` **{number, number, number}** Position as a vector.
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## celestialBodyAtmosphericDensityAtPosition
+
+**Extends SpaceCenter**
+
+The atmospheric density at the given position, in <math>kg/m^3</math>,
+in the given reference frame.
+
+**Parameters**
+
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `position` **{number, number, number}** The position vector at which to measure the density.
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## celestialBodyTemperatureAt
+
+**Extends SpaceCenter**
+
+The temperature on the body at the given position, in the given reference frame.
+
+ This calculation is performed using the bodies current position, which means that
+the value could be wrong if you want to know the temperature in the far future.
+
+**Parameters**
+
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `position` **{number, number, number}** Position as a vector.
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## celestialBodyDensityAt
+
+**Extends SpaceCenter**
+
+Gets the air density, in <math>kg/m^3</math>, for the specified
+altitude above sea level, in meters.
+ This is an approximation, because actual calculations, taking sun exposure into account
+to compute air temperature, require us to know the exact point on the body where the
+density is to be computed (knowing the altitude is not enough).
+However, the difference is small for high altitudes, so it makes very little difference
+for trajectory prediction.
+
+**Parameters**
+
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `altitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## celestialBodyPressureAt
+
+**Extends SpaceCenter**
+
+Gets the air pressure, in Pascals, for the specified
+altitude above sea level, in meters.
+
+**Parameters**
+
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `altitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1355,11 +1635,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The biomes at the given latitude and longitude, in degrees.
+The biome at the given latitude and longitude, in degrees.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 -   `latitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 -   `longitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
@@ -1369,14 +1649,15 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Returns the position vector of the center of the body in the specified reference frame.
- <param name="referenceFrame">
- </param>
+The position of the center of the body, in the specified reference frame.
+Returns: The position as a vector.
+<param name="referenceFrame">The reference frame that the returned
+position vector is in.</param>
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1384,14 +1665,16 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Returns the velocity vector of the body in the specified reference frame.
- <param name="referenceFrame">
- </param>
+The linear velocity of the body, in the specified reference frame.
+Returns: The velocity as a vector. The vector points in the direction of travel,
+and its magnitude is the speed of the body in meters per second.
+<param name="referenceFrame">The reference frame that the returned
+velocity vector is in.</param>
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1399,14 +1682,15 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Returns the rotation of the body in the specified reference frame.
- <param name="referenceFrame">
- </param>
+The rotation of the body, in the specified reference frame.
+Returns: The rotation as a quaternion of the form <math>(x, y, z, w)</math>.
+<param name="referenceFrame">The reference frame that the returned
+rotation is in.</param>
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1414,15 +1698,16 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Returns the direction in which the north pole of the celestial body is
-pointing, as a unit vector, in the specified reference frame.
- <param name="referenceFrame">
- </param>
+The direction in which the north pole of the celestial body is pointing,
+in the specified reference frame.
+Returns: The direction as a unit vector.
+<param name="referenceFrame">The reference frame that the returned
+direction is in.</param>
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1430,17 +1715,17 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Returns the angular velocity of the body in the specified reference
-frame. The magnitude of the vector is the rotational speed of the body, in
-radians per second, and the direction of the vector indicates the axis of
-rotation, using the right-hand rule.
- <param name="referenceFrame">
- </param>
+The angular velocity of the body in the specified reference frame.
+Returns: The angular velocity as a vector. The magnitude of the vector is the rotational
+speed of the body, in radians per second. The direction of the vector indicates the axis
+of rotation, using the right-hand rule.
+<param name="referenceFrame">The reference frame the returned
+angular velocity is in.</param>
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1452,7 +1737,7 @@ The name of the body.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1464,7 +1749,7 @@ A list of celestial bodies that are in orbit around this celestial body.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1476,7 +1761,7 @@ The mass of the body, in kilograms.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1489,7 +1774,7 @@ gravitational parameter</a> of the body in <math>m^3s^{-2}</math>.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1497,11 +1782,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The acceleration due to gravity at sea level (mean altitude) on the body, in <math>m/s^2</math>.
+The acceleration due to gravity at sea level (mean altitude) on the body,
+in <math>m/s^2</math>.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1513,7 +1799,7 @@ The sidereal rotational period of the body, in seconds.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1525,7 +1811,33 @@ The rotational speed of the body, in radians per second.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## celestialBodyGetRotationAngle
+
+**Extends SpaceCenter**
+
+The current rotation angle of the body, in radians.
+A value between 0 and <math>2\\pi</math>
+
+**Parameters**
+
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## celestialBodyGetInitialRotation
+
+**Extends SpaceCenter**
+
+The initial rotation angle of the body (at UT 0), in radians.
+A value between 0 and <math>2\\pi</math>
+
+**Parameters**
+
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1537,7 +1849,7 @@ The equatorial radius of the body, in meters.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1549,7 +1861,7 @@ The radius of the sphere of influence of the body, in meters.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1561,7 +1873,7 @@ The orbit of the body.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1569,11 +1881,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-<c>true</c> if the body has an atmosphere.
+<summary>true if the body has an atmosphere.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1585,7 +1897,7 @@ The depth of the atmosphere, in meters.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1593,11 +1905,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-<c>true</c> if there is oxygen in the atmosphere, required for air-breathing engines.
+<summary>true if there is oxygen in the atmosphere, required for air-breathing engines.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1609,7 +1921,7 @@ The biomes present on this body.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1617,11 +1929,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The altitude, in meters, above which a vessel is considered to be flying "high" when doing science.
+The altitude, in meters, above which a vessel is considered to be
+flying "high" when doing science.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1629,11 +1942,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The altitude, in meters, above which a vessel is considered to be in "high" space when doing science.
+The altitude, in meters, above which a vessel is considered to be
+in "high" space when doing science.
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1651,7 +1965,7 @@ towards the equator at 90°E longitude.</description></item></list>
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1668,7 +1982,7 @@ equator.</description></item></list>
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1676,7 +1990,7 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Gets the reference frame that is fixed relative to this celestial body, but
+The reference frame that is fixed relative to this celestial body, but
 orientated with the body's orbital prograde/normal/radial directions.
 <list type="bullet"><item><description>The origin is at the center of the body.
 </description></item><item><description>The axes rotate with the orbital prograde/normal/radial
@@ -1687,7 +2001,679 @@ directions.</description></item><item><description>The x-axis points in the orbi
 
 **Parameters**
 
--   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `celestialBody` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## commLinkGetType
+
+**Extends SpaceCenter**
+
+The type of link.
+
+**Parameters**
+
+-   `commLink` **Long** A long value representing the id for the SpaceCenter.CommLink
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## commLinkGetSignalStrength
+
+**Extends SpaceCenter**
+
+Signal strength of the link.
+
+**Parameters**
+
+-   `commLink` **Long** A long value representing the id for the SpaceCenter.CommLink
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## commLinkGetStart
+
+**Extends SpaceCenter**
+
+Start point of the link.
+
+**Parameters**
+
+-   `commLink` **Long** A long value representing the id for the SpaceCenter.CommLink
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## commLinkGetEnd
+
+**Extends SpaceCenter**
+
+Start point of the link.
+
+**Parameters**
+
+-   `commLink` **Long** A long value representing the id for the SpaceCenter.CommLink
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## commNodeGetName
+
+**Extends SpaceCenter**
+
+Name of the communication node.
+
+**Parameters**
+
+-   `commNode` **Long** A long value representing the id for the SpaceCenter.CommNode
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## commNodeGetIsHome
+
+**Extends SpaceCenter**
+
+Whether the communication node is on Kerbin.
+
+**Parameters**
+
+-   `commNode` **Long** A long value representing the id for the SpaceCenter.CommNode
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## commNodeGetIsControlPoint
+
+**Extends SpaceCenter**
+
+Whether the communication node is a control point, for example a manned vessel.
+
+**Parameters**
+
+-   `commNode` **Long** A long value representing the id for the SpaceCenter.CommNode
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## commNodeGetIsVessel
+
+**Extends SpaceCenter**
+
+Whether the communication node is a vessel.
+
+**Parameters**
+
+-   `commNode` **Long** A long value representing the id for the SpaceCenter.CommNode
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## commNodeGetVessel
+
+**Extends SpaceCenter**
+
+The vessel for this communication node.
+
+**Parameters**
+
+-   `commNode` **Long** A long value representing the id for the SpaceCenter.CommNode
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## commsGetCanCommunicate
+
+**Extends SpaceCenter**
+
+Whether the vessel can communicate with KSC.
+
+**Parameters**
+
+-   `comms` **Long** A long value representing the id for the SpaceCenter.Comms
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## commsGetCanTransmitScience
+
+**Extends SpaceCenter**
+
+Whether the vessel can transmit science data to KSC.
+
+**Parameters**
+
+-   `comms` **Long** A long value representing the id for the SpaceCenter.Comms
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## commsGetSignalStrength
+
+**Extends SpaceCenter**
+
+Signal strength to KSC.
+
+**Parameters**
+
+-   `comms` **Long** A long value representing the id for the SpaceCenter.Comms
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## commsGetSignalDelay
+
+**Extends SpaceCenter**
+
+Signal delay to KSC in seconds.
+
+**Parameters**
+
+-   `comms` **Long** A long value representing the id for the SpaceCenter.Comms
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## commsGetPower
+
+**Extends SpaceCenter**
+
+The combined power of all active antennae on the vessel.
+
+**Parameters**
+
+-   `comms` **Long** A long value representing the id for the SpaceCenter.Comms
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## commsGetControlPath
+
+**Extends SpaceCenter**
+
+The communication path used to control the vessel.
+
+**Parameters**
+
+-   `comms` **Long** A long value representing the id for the SpaceCenter.Comms
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractCancel
+
+**Extends SpaceCenter**
+
+Cancel an active contract.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **void** 
+
+## contractAccept
+
+**Extends SpaceCenter**
+
+Accept an offered contract.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **void** 
+
+## contractDecline
+
+**Extends SpaceCenter**
+
+Decline an offered contract.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **void** 
+
+## contractGetType
+
+**Extends SpaceCenter**
+
+Type of the contract.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetTitle
+
+**Extends SpaceCenter**
+
+Title of the contract.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetDescription
+
+**Extends SpaceCenter**
+
+Description of the contract.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetNotes
+
+**Extends SpaceCenter**
+
+Notes for the contract.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetSynopsis
+
+**Extends SpaceCenter**
+
+Synopsis for the contract.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetKeywords
+
+**Extends SpaceCenter**
+
+Keywords for the contract.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetState
+
+**Extends SpaceCenter**
+
+State of the contract.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetActive
+
+**Extends SpaceCenter**
+
+Whether the contract is active.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetFailed
+
+**Extends SpaceCenter**
+
+Whether the contract has been failed.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetSeen
+
+**Extends SpaceCenter**
+
+Whether the contract has been seen.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetRead
+
+**Extends SpaceCenter**
+
+Whether the contract has been read.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetCanBeCanceled
+
+**Extends SpaceCenter**
+
+Whether the contract can be canceled.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetCanBeDeclined
+
+**Extends SpaceCenter**
+
+Whether the contract can be declined.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetCanBeFailed
+
+**Extends SpaceCenter**
+
+Whether the contract can be failed.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetFundsAdvance
+
+**Extends SpaceCenter**
+
+Funds received when accepting the contract.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetFundsCompletion
+
+**Extends SpaceCenter**
+
+Funds received on completion of the contract.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetFundsFailure
+
+**Extends SpaceCenter**
+
+Funds lost if the contract is failed.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetReputationCompletion
+
+**Extends SpaceCenter**
+
+Reputation gained on completion of the contract.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetReputationFailure
+
+**Extends SpaceCenter**
+
+Reputation lost if the contract is failed.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetScienceCompletion
+
+**Extends SpaceCenter**
+
+Science gained on completion of the contract.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractGetParameters
+
+**Extends SpaceCenter**
+
+Parameters for the contract.
+
+**Parameters**
+
+-   `contract` **Long** A long value representing the id for the SpaceCenter.Contract
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractManagerGetTypes
+
+**Extends SpaceCenter**
+
+A list of all contract types.
+
+**Parameters**
+
+-   `contractManager` **Long** A long value representing the id for the SpaceCenter.ContractManager
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractManagerGetAllContracts
+
+**Extends SpaceCenter**
+
+A list of all contracts.
+
+**Parameters**
+
+-   `contractManager` **Long** A long value representing the id for the SpaceCenter.ContractManager
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractManagerGetActiveContracts
+
+**Extends SpaceCenter**
+
+A list of all active contracts.
+
+**Parameters**
+
+-   `contractManager` **Long** A long value representing the id for the SpaceCenter.ContractManager
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractManagerGetOfferedContracts
+
+**Extends SpaceCenter**
+
+A list of all offered, but unaccepted, contracts.
+
+**Parameters**
+
+-   `contractManager` **Long** A long value representing the id for the SpaceCenter.ContractManager
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractManagerGetCompletedContracts
+
+**Extends SpaceCenter**
+
+A list of all completed contracts.
+
+**Parameters**
+
+-   `contractManager` **Long** A long value representing the id for the SpaceCenter.ContractManager
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractManagerGetFailedContracts
+
+**Extends SpaceCenter**
+
+A list of all failed contracts.
+
+**Parameters**
+
+-   `contractManager` **Long** A long value representing the id for the SpaceCenter.ContractManager
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractParameterGetTitle
+
+**Extends SpaceCenter**
+
+Title of the parameter.
+
+**Parameters**
+
+-   `contractParameter` **Long** A long value representing the id for the SpaceCenter.ContractParameter
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractParameterGetNotes
+
+**Extends SpaceCenter**
+
+Notes for the parameter.
+
+**Parameters**
+
+-   `contractParameter` **Long** A long value representing the id for the SpaceCenter.ContractParameter
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractParameterGetChildren
+
+**Extends SpaceCenter**
+
+Child contract parameters.
+
+**Parameters**
+
+-   `contractParameter` **Long** A long value representing the id for the SpaceCenter.ContractParameter
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractParameterGetCompleted
+
+**Extends SpaceCenter**
+
+Whether the parameter has been completed.
+
+**Parameters**
+
+-   `contractParameter` **Long** A long value representing the id for the SpaceCenter.ContractParameter
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractParameterGetFailed
+
+**Extends SpaceCenter**
+
+Whether the parameter has been failed.
+
+**Parameters**
+
+-   `contractParameter` **Long** A long value representing the id for the SpaceCenter.ContractParameter
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractParameterGetOptional
+
+**Extends SpaceCenter**
+
+Whether the contract parameter is optional.
+
+**Parameters**
+
+-   `contractParameter` **Long** A long value representing the id for the SpaceCenter.ContractParameter
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractParameterGetFundsCompletion
+
+**Extends SpaceCenter**
+
+Funds received on completion of the contract parameter.
+
+**Parameters**
+
+-   `contractParameter` **Long** A long value representing the id for the SpaceCenter.ContractParameter
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractParameterGetFundsFailure
+
+**Extends SpaceCenter**
+
+Funds lost if the contract parameter is failed.
+
+**Parameters**
+
+-   `contractParameter` **Long** A long value representing the id for the SpaceCenter.ContractParameter
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractParameterGetReputationCompletion
+
+**Extends SpaceCenter**
+
+Reputation gained on completion of the contract parameter.
+
+**Parameters**
+
+-   `contractParameter` **Long** A long value representing the id for the SpaceCenter.ContractParameter
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractParameterGetReputationFailure
+
+**Extends SpaceCenter**
+
+Reputation lost if the contract parameter is failed.
+
+**Parameters**
+
+-   `contractParameter` **Long** A long value representing the id for the SpaceCenter.ContractParameter
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## contractParameterGetScienceCompletion
+
+**Extends SpaceCenter**
+
+Science gained on completion of the contract parameter.
+
+**Parameters**
+
+-   `contractParameter` **Long** A long value representing the id for the SpaceCenter.ContractParameter
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1696,11 +2682,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Activates the next stage. Equivalent to pressing the space bar in-game.
- <returns>A list of vessel objects that are jettisoned from the active vessel.</returns>
+Returns: A list of vessel objects that are jettisoned from the active vessel.
+ When called, the active vessel may change. It is therefore possible that,
+after calling this function, the object(s) returned by previous call(s) to
+[M:SpaceCenter.ActiveVessel](M:SpaceCenter.ActiveVessel) no longer refer to the active vessel.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1708,12 +2697,17 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Returns <c>true</c> if the given action group is enabled.
+Returns true if the given action group is enabled.
+<param name="group">
+A number between 0 and 9 inclusive,
+or between 0 and 250 inclusive when the <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/67235-122dec1016-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech/">Extended Action Groups mod</a> is installed.
+</param>
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
--   `group` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** A number between 0 and 9 inclusive.
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `group` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** A number between 0 and 9 inclusive,
+    or between 0 and 250 inclusive when the &lt;a href="<https://forum.kerbalspaceprogram.com/index.php?/topic/67235-122dec1016-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech/,Extended> Action Groups mod</a> is installed.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1721,16 +2715,18 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Sets the state of the given action group (a value between 0 and 9
-inclusive).
-  <param name="state">
- </param>
+Sets the state of the given action group.
+<param name="group">
+A number between 0 and 9 inclusive,
+or between 0 and 250 inclusive when the <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/67235-122dec1016-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech/">Extended Action Groups mod</a> is installed.
+</param>
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
--   `group` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** A number between 0 and 9 inclusive.
--   `state` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** \-
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `group` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** A number between 0 and 9 inclusive,
+    or between 0 and 250 inclusive when the &lt;a href="<https://forum.kerbalspaceprogram.com/index.php?/topic/67235-122dec1016-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech/,Extended> Action Groups mod</a> is installed.
+-   `state` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
 
@@ -1739,11 +2735,16 @@ Returns **void**
 **Extends SpaceCenter**
 
 Toggles the state of the given action group.
+<param name="group">
+A number between 0 and 9 inclusive,
+or between 0 and 250 inclusive when the <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/67235-122dec1016-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech/">Extended Action Groups mod</a> is installed.
+</param>
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
--   `group` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** A number between 0 and 9 inclusive.
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `group` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** A number between 0 and 9 inclusive,
+    or between 0 and 250 inclusive when the &lt;a href="<https://forum.kerbalspaceprogram.com/index.php?/topic/67235-122dec1016-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech/,Extended> Action Groups mod</a> is installed.
 
 Returns **void** 
 
@@ -1758,7 +2759,7 @@ in the prograde, normal and radial directions.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 -   `ut` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Universal time of the maneuver node.
 -   `prograde` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Delta-v in the prograde direction.
 -   `normal` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Delta-v in the normal direction.
@@ -1774,20 +2775,44 @@ Remove all maneuver nodes.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **void** 
+
+## controlGetState
+
+**Extends SpaceCenter**
+
+The control state of the vessel.
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## controlGetSource
+
+**Extends SpaceCenter**
+
+The source of the vessels control, for example by a kerbal or a probe core.
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
 ## controlGetSas
 
 **Extends SpaceCenter**
 
 The state of SAS.
- <remarks>Equivalent to [M:SpaceCenter.AutoPilot.SAS](M:SpaceCenter.AutoPilot.SAS)
+<remarks>Equivalent to [M:SpaceCenter.AutoPilot.SAS](M:SpaceCenter.AutoPilot.SAS)
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1796,11 +2821,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The state of SAS.
- <remarks>Equivalent to [M:SpaceCenter.AutoPilot.SAS](M:SpaceCenter.AutoPilot.SAS)
+<remarks>Equivalent to [M:SpaceCenter.AutoPilot.SAS](M:SpaceCenter.AutoPilot.SAS)
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -1812,11 +2837,11 @@ Returns **void**
 The current [T:SpaceCenter.SASMode](T:SpaceCenter.SASMode).
 These modes are equivalent to the mode buttons to
 the left of the navball that appear when SAS is enabled.
- <remarks>Equivalent to [M:SpaceCenter.AutoPilot.SASMode](M:SpaceCenter.AutoPilot.SASMode)
+<remarks>Equivalent to [M:SpaceCenter.AutoPilot.SASMode](M:SpaceCenter.AutoPilot.SASMode)
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1827,12 +2852,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 The current [T:SpaceCenter.SASMode](T:SpaceCenter.SASMode).
 These modes are equivalent to the mode buttons to
 the left of the navball that appear when SAS is enabled.
- <remarks>Equivalent to [M:SpaceCenter.AutoPilot.SASMode](M:SpaceCenter.AutoPilot.SASMode)
+<remarks>Equivalent to [M:SpaceCenter.AutoPilot.SASMode](M:SpaceCenter.AutoPilot.SASMode)
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.SASMode see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `value` **Long** A long value representing the id for the SpaceCenter.SASMode
 
 Returns **void** 
 
@@ -1845,7 +2870,7 @@ This is the mode displayed next to the speed at the top of the navball.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1858,8 +2883,8 @@ This is the mode displayed next to the speed at the top of the navball.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.SpeedMode see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `value` **Long** A long value representing the id for the SpaceCenter.SpeedMode
 
 Returns **void** 
 
@@ -1871,7 +2896,7 @@ The state of RCS.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1883,7 +2908,36 @@ The state of RCS.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## controlGetReactionWheels
+
+**Extends SpaceCenter**
+
+Returns whether all reactive wheels on the vessel are active,
+and sets the active state of all reaction wheels.
+See [M:SpaceCenter.ReactionWheel.Active](M:SpaceCenter.ReactionWheel.Active).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## controlSetReactionWheels
+
+**Extends SpaceCenter**
+
+Returns whether all reactive wheels on the vessel are active,
+and sets the active state of all reaction wheels.
+See [M:SpaceCenter.ReactionWheel.Active](M:SpaceCenter.ReactionWheel.Active).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -1896,7 +2950,7 @@ The state of the landing gear/legs.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1908,7 +2962,69 @@ The state of the landing gear/legs.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## controlGetLegs
+
+**Extends SpaceCenter**
+
+Returns whether all landing legs on the vessel are deployed,
+and sets the deployment state of all landing legs.
+Does not include wheels (for example landing gear).
+See [M:SpaceCenter.Leg.Deployed](M:SpaceCenter.Leg.Deployed).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## controlSetLegs
+
+**Extends SpaceCenter**
+
+Returns whether all landing legs on the vessel are deployed,
+and sets the deployment state of all landing legs.
+Does not include wheels (for example landing gear).
+See [M:SpaceCenter.Leg.Deployed](M:SpaceCenter.Leg.Deployed).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## controlGetWheels
+
+**Extends SpaceCenter**
+
+Returns whether all wheels on the vessel are deployed,
+and sets the deployment state of all wheels.
+Does not include landing legs.
+See [M:SpaceCenter.Wheel.Deployed](M:SpaceCenter.Wheel.Deployed).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## controlSetWheels
+
+**Extends SpaceCenter**
+
+Returns whether all wheels on the vessel are deployed,
+and sets the deployment state of all wheels.
+Does not include landing legs.
+See [M:SpaceCenter.Wheel.Deployed](M:SpaceCenter.Wheel.Deployed).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -1921,7 +3037,7 @@ The state of the lights.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1933,7 +3049,7 @@ The state of the lights.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -1946,7 +3062,7 @@ The state of the wheel brakes.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1958,7 +3074,241 @@ The state of the wheel brakes.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## controlGetAntennas
+
+**Extends SpaceCenter**
+
+Returns whether all antennas on the vessel are deployed,
+and sets the deployment state of all antennas.
+See [M:SpaceCenter.Antenna.Deployed](M:SpaceCenter.Antenna.Deployed).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## controlSetAntennas
+
+**Extends SpaceCenter**
+
+Returns whether all antennas on the vessel are deployed,
+and sets the deployment state of all antennas.
+See [M:SpaceCenter.Antenna.Deployed](M:SpaceCenter.Antenna.Deployed).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## controlGetCargoBays
+
+**Extends SpaceCenter**
+
+Returns whether any of the cargo bays on the vessel are open,
+and sets the open state of all cargo bays.
+See [M:SpaceCenter.CargoBay.Open](M:SpaceCenter.CargoBay.Open).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## controlSetCargoBays
+
+**Extends SpaceCenter**
+
+Returns whether any of the cargo bays on the vessel are open,
+and sets the open state of all cargo bays.
+See [M:SpaceCenter.CargoBay.Open](M:SpaceCenter.CargoBay.Open).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## controlGetIntakes
+
+**Extends SpaceCenter**
+
+Returns whether all of the air intakes on the vessel are open,
+and sets the open state of all air intakes.
+See [M:SpaceCenter.Intake.Open](M:SpaceCenter.Intake.Open).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## controlSetIntakes
+
+**Extends SpaceCenter**
+
+Returns whether all of the air intakes on the vessel are open,
+and sets the open state of all air intakes.
+See [M:SpaceCenter.Intake.Open](M:SpaceCenter.Intake.Open).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## controlGetParachutes
+
+**Extends SpaceCenter**
+
+Returns whether all parachutes on the vessel are deployed,
+and sets the deployment state of all parachutes.
+Cannot be set to false.
+See [M:SpaceCenter.Parachute.Deployed](M:SpaceCenter.Parachute.Deployed).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## controlSetParachutes
+
+**Extends SpaceCenter**
+
+Returns whether all parachutes on the vessel are deployed,
+and sets the deployment state of all parachutes.
+Cannot be set to false.
+See [M:SpaceCenter.Parachute.Deployed](M:SpaceCenter.Parachute.Deployed).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## controlGetRadiators
+
+**Extends SpaceCenter**
+
+Returns whether all radiators on the vessel are deployed,
+and sets the deployment state of all radiators.
+See [M:SpaceCenter.Radiator.Deployed](M:SpaceCenter.Radiator.Deployed).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## controlSetRadiators
+
+**Extends SpaceCenter**
+
+Returns whether all radiators on the vessel are deployed,
+and sets the deployment state of all radiators.
+See [M:SpaceCenter.Radiator.Deployed](M:SpaceCenter.Radiator.Deployed).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## controlGetResourceHarvesters
+
+**Extends SpaceCenter**
+
+Returns whether all of the resource harvesters on the vessel are deployed,
+and sets the deployment state of all resource harvesters.
+See [M:SpaceCenter.ResourceHarvester.Deployed](M:SpaceCenter.ResourceHarvester.Deployed).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## controlSetResourceHarvesters
+
+**Extends SpaceCenter**
+
+Returns whether all of the resource harvesters on the vessel are deployed,
+and sets the deployment state of all resource harvesters.
+See [M:SpaceCenter.ResourceHarvester.Deployed](M:SpaceCenter.ResourceHarvester.Deployed).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## controlGetResourceHarvestersActive
+
+**Extends SpaceCenter**
+
+Returns whether any of the resource harvesters on the vessel are active,
+and sets the active state of all resource harvesters.
+See [M:SpaceCenter.ResourceHarvester.Active](M:SpaceCenter.ResourceHarvester.Active).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## controlSetResourceHarvestersActive
+
+**Extends SpaceCenter**
+
+Returns whether any of the resource harvesters on the vessel are active,
+and sets the active state of all resource harvesters.
+See [M:SpaceCenter.ResourceHarvester.Active](M:SpaceCenter.ResourceHarvester.Active).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## controlGetSolarPanels
+
+**Extends SpaceCenter**
+
+Returns whether all solar panels on the vessel are deployed,
+and sets the deployment state of all solar panels.
+See [M:SpaceCenter.SolarPanel.Deployed](M:SpaceCenter.SolarPanel.Deployed).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## controlSetSolarPanels
+
+**Extends SpaceCenter**
+
+Returns whether all solar panels on the vessel are deployed,
+and sets the deployment state of all solar panels.
+See [M:SpaceCenter.SolarPanel.Deployed](M:SpaceCenter.SolarPanel.Deployed).
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -1971,7 +3321,7 @@ The state of the abort action group.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -1983,7 +3333,7 @@ The state of the abort action group.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -1996,7 +3346,7 @@ The state of the throttle. A value between 0 and 1.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2008,8 +3358,43 @@ The state of the throttle. A value between 0 and 1.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+Returns **void** 
+
+## controlGetInputMode
+
+**Extends SpaceCenter**
+
+Sets the behavior of the pitch, yaw, roll and translation control inputs.
+When set to additive, these inputs are added to the vessels current inputs.
+This mode is the default.
+When set to override, these inputs (if non-zero) override the vessels inputs.
+This mode prevents keyboard control, or SAS, from interfering with the controls when
+they are set.
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## controlSetInputMode
+
+**Extends SpaceCenter**
+
+Sets the behavior of the pitch, yaw, roll and translation control inputs.
+When set to additive, these inputs are added to the vessels current inputs.
+This mode is the default.
+When set to override, these inputs (if non-zero) override the vessels inputs.
+This mode prevents keyboard control, or SAS, from interfering with the controls when
+they are set.
+
+**Parameters**
+
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+-   `value` **Long** A long value representing the id for the SpaceCenter.ControlInputMode
 
 Returns **void** 
 
@@ -2023,7 +3408,7 @@ Equivalent to the w and s keys.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2037,7 +3422,7 @@ Equivalent to the w and s keys.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -2052,7 +3437,7 @@ Equivalent to the a and d keys.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2066,7 +3451,7 @@ Equivalent to the a and d keys.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -2081,7 +3466,7 @@ Equivalent to the q and e keys.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2095,7 +3480,7 @@ Equivalent to the q and e keys.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -2110,7 +3495,7 @@ Equivalent to the h and n keys.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2124,7 +3509,7 @@ Equivalent to the h and n keys.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -2139,7 +3524,7 @@ Equivalent to the i and k keys.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2153,7 +3538,7 @@ Equivalent to the i and k keys.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -2168,7 +3553,7 @@ Equivalent to the j and l keys.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2182,7 +3567,7 @@ Equivalent to the j and l keys.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -2198,7 +3583,7 @@ the wheels backwards.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2213,7 +3598,7 @@ the wheels backwards.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -2228,7 +3613,7 @@ A value of 1 steers to the left, and a value of -1 steers to the right.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2242,7 +3627,7 @@ A value of 1 steers to the left, and a value of -1 steers to the right.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -2256,7 +3641,7 @@ the in-game UI.
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2268,7 +3653,200 @@ Returns a list of all existing maneuver nodes, ordered by time from first to las
 
 **Parameters**
 
--   `control` **Long** A long value representing the id for the SpaceCenter.Control see [Long.js]<https://www.npmjs.com/package/long>
+-   `control` **Long** A long value representing the id for the SpaceCenter.Control
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## crewMemberGetName
+
+**Extends SpaceCenter**
+
+The crew members name.
+
+**Parameters**
+
+-   `crewMember` **Long** A long value representing the id for the SpaceCenter.CrewMember
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## crewMemberSetName
+
+**Extends SpaceCenter**
+
+The crew members name.
+
+**Parameters**
+
+-   `crewMember` **Long** A long value representing the id for the SpaceCenter.CrewMember
+-   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+Returns **void** 
+
+## crewMemberGetType
+
+**Extends SpaceCenter**
+
+The type of crew member.
+
+**Parameters**
+
+-   `crewMember` **Long** A long value representing the id for the SpaceCenter.CrewMember
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## crewMemberGetOnMission
+
+**Extends SpaceCenter**
+
+Whether the crew member is on a mission.
+
+**Parameters**
+
+-   `crewMember` **Long** A long value representing the id for the SpaceCenter.CrewMember
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## crewMemberGetCourage
+
+**Extends SpaceCenter**
+
+The crew members courage.
+
+**Parameters**
+
+-   `crewMember` **Long** A long value representing the id for the SpaceCenter.CrewMember
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## crewMemberSetCourage
+
+**Extends SpaceCenter**
+
+The crew members courage.
+
+**Parameters**
+
+-   `crewMember` **Long** A long value representing the id for the SpaceCenter.CrewMember
+-   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+Returns **void** 
+
+## crewMemberGetStupidity
+
+**Extends SpaceCenter**
+
+The crew members stupidity.
+
+**Parameters**
+
+-   `crewMember` **Long** A long value representing the id for the SpaceCenter.CrewMember
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## crewMemberSetStupidity
+
+**Extends SpaceCenter**
+
+The crew members stupidity.
+
+**Parameters**
+
+-   `crewMember` **Long** A long value representing the id for the SpaceCenter.CrewMember
+-   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+Returns **void** 
+
+## crewMemberGetExperience
+
+**Extends SpaceCenter**
+
+The crew members experience.
+
+**Parameters**
+
+-   `crewMember` **Long** A long value representing the id for the SpaceCenter.CrewMember
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## crewMemberSetExperience
+
+**Extends SpaceCenter**
+
+The crew members experience.
+
+**Parameters**
+
+-   `crewMember` **Long** A long value representing the id for the SpaceCenter.CrewMember
+-   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+Returns **void** 
+
+## crewMemberGetBadass
+
+**Extends SpaceCenter**
+
+Whether the crew member is a badass.
+
+**Parameters**
+
+-   `crewMember` **Long** A long value representing the id for the SpaceCenter.CrewMember
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## crewMemberSetBadass
+
+**Extends SpaceCenter**
+
+Whether the crew member is a badass.
+
+**Parameters**
+
+-   `crewMember` **Long** A long value representing the id for the SpaceCenter.CrewMember
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## crewMemberGetVeteran
+
+**Extends SpaceCenter**
+
+Whether the crew member is a veteran.
+
+**Parameters**
+
+-   `crewMember` **Long** A long value representing the id for the SpaceCenter.CrewMember
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## crewMemberSetVeteran
+
+**Extends SpaceCenter**
+
+Whether the crew member is a veteran.
+
+**Parameters**
+
+-   `crewMember` **Long** A long value representing the id for the SpaceCenter.CrewMember
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## flightSimulateAerodynamicForceAt
+
+**Extends SpaceCenter**
+
+Simulate and return the total aerodynamic forces acting on the vessel,
+if it where to be traveling with the given velocity at the given position in the
+atmosphere of the given celestial body.
+Returns: A vector pointing in the direction that the force acts,
+with its magnitude equal to the strength of the force in Newtons.
+
+**Parameters**
+
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
+-   `body` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `position` **{number, number, number}** 
+-   `velocity` **{number, number, number}** 
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2280,7 +3858,7 @@ The current G force acting on the vessel in <math>m/s^2</math>.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2293,7 +3871,7 @@ Measured from the center of mass of the vessel.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2306,7 +3884,7 @@ Measured from the center of mass of the vessel.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2319,7 +3897,7 @@ Measured from the center of mass of the vessel.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2332,7 +3910,7 @@ and is negative when the vessel is over the sea.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2344,7 +3922,7 @@ The <a href="https://en.wikipedia.org/wiki/Latitude">latitude</a> of the vessel 
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2356,7 +3934,7 @@ The <a href="https://en.wikipedia.org/wiki/Longitude">longitude</a> of the vesse
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2364,12 +3942,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The velocity vector of the vessel. The magnitude of the vector is the speed of the vessel in meters per second.
-The direction of the vector is the direction of the vessels motion.
+The velocity of the vessel, in the reference frame [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame).
+Returns: The velocity as a vector. The vector points in the direction of travel,
+and its magnitude is the speed of the vessel in meters per second.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2377,11 +3956,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The speed of the vessel in meters per second.
+The speed of the vessel in meters per second,
+in the reference frame [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame).
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2389,11 +3969,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The horizontal speed of the vessel in meters per second.
+The horizontal speed of the vessel in meters per second,
+in the reference frame [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame).
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2401,11 +3982,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The vertical speed of the vessel in meters per second.
+The vertical speed of the vessel in meters per second,
+in the reference frame [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame).
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2413,11 +3995,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The position of the center of mass of the vessel.
+The position of the center of mass of the vessel,
+in the reference frame [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame)<returns>The position as a vector.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2425,11 +4008,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The rotation of the vessel.
+The rotation of the vessel, in the reference frame [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame)<returns>The rotation as a quaternion of the form <math>(x, y, z, w)</math>.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2437,11 +4020,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The direction vector that the vessel is pointing in.
+The direction that the vessel is pointing in,
+in the reference frame [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame).
+Returns: The direction as a unit vector.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2449,11 +4034,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The pitch angle of the vessel relative to the horizon, in degrees. A value between -90° and +90°.
+The pitch of the vessel relative to the horizon, in degrees.
+A value between -90° and +90°.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2461,11 +4047,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The heading angle of the vessel relative to north, in degrees. A value between 0° and 360°.
+The heading of the vessel (its angle relative to north), in degrees.
+A value between 0° and 360°.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2473,11 +4060,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The roll angle of the vessel relative to the horizon, in degrees. A value between -180° and +180°.
+The roll of the vessel relative to the horizon, in degrees.
+A value between -180° and +180°.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2485,11 +4073,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The unit direction vector pointing in the prograde direction.
+The prograde direction of the vessels orbit,
+in the reference frame [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame).
+Returns: The direction as a unit vector.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2497,11 +4087,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The unit direction vector pointing in the retrograde direction.
+The retrograde direction of the vessels orbit,
+in the reference frame [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame).
+Returns: The direction as a unit vector.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2509,11 +4101,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The unit direction vector pointing in the normal direction.
+The direction normal to the vessels orbit,
+in the reference frame [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame).
+Returns: The direction as a unit vector.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2521,11 +4115,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The unit direction vector pointing in the anti-normal direction.
+The direction opposite to the normal of the vessels orbit,
+in the reference frame [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame).
+Returns: The direction as a unit vector.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2533,11 +4129,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The unit direction vector pointing in the radial direction.
+The radial direction of the vessels orbit,
+in the reference frame [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame).
+Returns: The direction as a unit vector.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2545,11 +4143,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The unit direction vector pointing in the anti-radial direction.
+The direction opposite to the radial direction of the vessels orbit,
+in the reference frame [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame).
+Returns: The direction as a unit vector.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2561,7 +4161,7 @@ The current density of the atmosphere around the vessel, in <math>kg/m^3</math>.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2569,13 +4169,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The dynamic pressure acting on the vessel, in Pascals. This is a measure of the strength of the
-aerodynamic forces. It is equal to <math>\\frac{1}{2} . \\mbox{air density} .  \\mbox{velocity}^2</math>.
+The dynamic pressure acting on the vessel, in Pascals. This is a measure of the
+strength of the aerodynamic forces. It is equal to
+<math>\\frac{1}{2} . \\mbox{air density} . \\mbox{velocity}^2</math>.
 It is commonly denoted <math>Q</math>.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2587,7 +4188,7 @@ The static atmospheric pressure at mean sea level, in Pascals.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2599,7 +4200,7 @@ The static atmospheric pressure acting on the vessel, in Pascals.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2607,12 +4208,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The total aerodynamic forces acting on the vessel, as a vector pointing in the direction of the force, with its
-magnitude equal to the strength of the force in Newtons.
+The total aerodynamic forces acting on the vessel,
+in reference frame [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame).
+Returns: A vector pointing in the direction that the force acts,
+with its magnitude equal to the strength of the force in Newtons.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2620,12 +4223,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The <a href="https://en.wikipedia.org/wiki/Aerodynamic_force">aerodynamic lift</a> currently acting on the vessel,
-as a vector pointing in the direction of the force, with its magnitude equal to the strength of the force in Newtons.
+The <a href="https://en.wikipedia.org/wiki/Aerodynamic_force">aerodynamic lift</a>
+currently acting on the vessel.
+Returns: A vector pointing in the direction that the force acts,
+with its magnitude equal to the strength of the force in Newtons.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2633,12 +4238,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The <a href="https://en.wikipedia.org/wiki/Aerodynamic_force">aerodynamic drag</a> currently acting on the vessel,
-as a vector pointing in the direction of the force, with its magnitude equal to the strength of the force in Newtons.
+The <a href="https://en.wikipedia.org/wiki/Aerodynamic_force">aerodynamic drag</a> currently acting on the vessel.
+Returns: A vector pointing in the direction of the force, with its magnitude
+equal to the strength of the force in Newtons.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2650,7 +4256,7 @@ The speed of sound, in the atmosphere around the vessel, in <math>m/s</math>.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2662,7 +4268,7 @@ The speed of the vessel, in multiples of the speed of sound.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2671,11 +4277,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The vessels Reynolds number.
-Requires <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/19321-105-ferram-aerospace-research-v01557-johnson-21816/">Ferram Aerospace Research</a>.
+ Requires <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/19321-130-ferram-aerospace-research-v0159-liebe-82117/">Ferram Aerospace Research</a>.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2683,11 +4289,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The <a href="https://en.wikipedia.org/wiki/True_airspeed">true air speed</a> of the vessel, in <math>m/s</math>.
+The <a href="https://en.wikipedia.org/wiki/True_airspeed">true air speed</a>
+of the vessel, in meters per second.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2695,11 +4302,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The <a href="https://en.wikipedia.org/wiki/Equivalent_airspeed">equivalent air speed</a> of the vessel, in <math>m/s</math>.
+The <a href="https://en.wikipedia.org/wiki/Equivalent_airspeed">equivalent air speed</a>
+of the vessel, in meters per second.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2707,12 +4315,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-An estimate of the current terminal velocity of the vessel, in <math>m/s</math>.
+An estimate of the current terminal velocity of the vessel, in meters per second.
 This is the speed at which the drag forces cancel out the force of gravity.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2720,11 +4328,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Gets the pitch angle between the orientation of the vessel and its velocity vector, in degrees.
+The pitch angle between the orientation of the vessel and its velocity vector,
+in degrees.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2732,11 +4341,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Gets the yaw angle between the orientation of the vessel and its velocity vector, in degrees.
+The yaw angle between the orientation of the vessel and its velocity vector, in degrees.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2744,12 +4353,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The <a href="https://en.wikipedia.org/wiki/Total_air_temperature">total air temperature</a> of the atmosphere
-around the vessel, in Kelvin. This temperature includes the [M:SpaceCenter.Flight.StaticAirTemperature](M:SpaceCenter.Flight.StaticAirTemperature) and the vessel's kinetic energy.
+The <a href="https://en.wikipedia.org/wiki/Total_air_temperature">total air temperature</a>
+of the atmosphere around the vessel, in Kelvin.
+This includes the [M:SpaceCenter.Flight.StaticAirTemperature](M:SpaceCenter.Flight.StaticAirTemperature) and the vessel's kinetic energy.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2757,12 +4367,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The <a href="https://en.wikipedia.org/wiki/Total_air_temperature">static (ambient) temperature</a> of the
-atmosphere around the vessel, in Kelvin.
+The <a href="https://en.wikipedia.org/wiki/Total_air_temperature">static (ambient)
+temperature</a> of the atmosphere around the vessel, in Kelvin.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2770,13 +4380,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Gets the current amount of stall, between 0 and 1. A value greater than 0.005 indicates a minor stall
-and a value greater than 0.5 indicates a large-scale stall.
-Requires <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/19321-105-ferram-aerospace-research-v01557-johnson-21816/">Ferram Aerospace Research</a>.
+The current amount of stall, between 0 and 1. A value greater than 0.005 indicates
+a minor stall and a value greater than 0.5 indicates a large-scale stall.
+ Requires <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/19321-130-ferram-aerospace-research-v0159-liebe-82117/">Ferram Aerospace Research</a>.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2784,13 +4394,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Gets the coefficient of drag. This is the amount of drag produced by the vessel. It depends on air speed,
-air density and wing area.
-Requires <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/19321-105-ferram-aerospace-research-v01557-johnson-21816/">Ferram Aerospace Research</a>.
+The coefficient of drag. This is the amount of drag produced by the vessel.
+It depends on air speed, air density and wing area.
+ Requires <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/19321-130-ferram-aerospace-research-v0159-liebe-82117/">Ferram Aerospace Research</a>.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2798,12 +4408,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Gets the coefficient of lift. This is the amount of lift produced by the vessel, and depends on air speed, air density and wing area.
-Requires <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/19321-105-ferram-aerospace-research-v01557-johnson-21816/">Ferram Aerospace Research</a>.
+The coefficient of lift. This is the amount of lift produced by the vessel, and
+depends on air speed, air density and wing area.
+ Requires <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/19321-130-ferram-aerospace-research-v0159-liebe-82117/">Ferram Aerospace Research</a>.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2811,12 +4422,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Gets the <a href="https://en.wikipedia.org/wiki/Ballistic_coefficient">ballistic coefficient</a>.
-Requires <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/19321-105-ferram-aerospace-research-v01557-johnson-21816/">Ferram Aerospace Research</a>.
+The <a href="https://en.wikipedia.org/wiki/Ballistic_coefficient">ballistic coefficient</a>.
+ Requires <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/19321-130-ferram-aerospace-research-v0159-liebe-82117/">Ferram Aerospace Research</a>.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2824,14 +4435,15 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Gets the thrust specific fuel consumption for the jet engines on the vessel. This is a measure of the
-efficiency of the engines, with a lower value indicating a more efficient vessel. This value is the
-number of Newtons of fuel that are burned, per hour, to produce one newton of thrust.
-Requires <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/19321-105-ferram-aerospace-research-v01557-johnson-21816/">Ferram Aerospace Research</a>.
+The thrust specific fuel consumption for the jet engines on the vessel. This is a
+measure of the efficiency of the engines, with a lower value indicating a more
+efficient vessel. This value is the number of Newtons of fuel that are burned,
+per hour, to produce one newton of thrust.
+ Requires <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/19321-130-ferram-aerospace-research-v0159-liebe-82117/">Ferram Aerospace Research</a>.
 
 **Parameters**
 
--   `flight` **Long** A long value representing the id for the SpaceCenter.Flight see [Long.js]<https://www.npmjs.com/package/long>
+-   `flight` **Long** A long value representing the id for the SpaceCenter.Flight
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2839,16 +4451,18 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Returns a vector whose direction the direction of the maneuver node burn, and whose magnitude
-is the delta-v of the burn in m/s.
- <param name="referenceFrame">
- </param>
-Does not change when executing the maneuver node. See [M:SpaceCenter.Node.RemainingBurnVector](M:SpaceCenter.Node.RemainingBurnVector).
+Returns the burn vector for the maneuver node.
+<param name="referenceFrame">The reference frame that the returned vector is in.
+Defaults to [M:SpaceCenter.Vessel.OrbitalReferenceFrame](M:SpaceCenter.Vessel.OrbitalReferenceFrame).</param>
+Returns: A vector whose direction is the direction of the maneuver node burn, and
+magnitude is the delta-v of the burn in meters per second.
+
+ Does not change when executing the maneuver node. See [M:SpaceCenter.Node.RemainingBurnVector](M:SpaceCenter.Node.RemainingBurnVector).
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2856,15 +4470,18 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Returns a vector whose direction the direction of the maneuver node burn, and whose magnitude
-is the delta-v of the burn in m/s. The direction and magnitude change as the burn is executed.
- <param name="referenceFrame">
- </param>
+Returns the remaining burn vector for the maneuver node.
+<param name="referenceFrame">The reference frame that the returned vector is in.
+Defaults to [M:SpaceCenter.Vessel.OrbitalReferenceFrame](M:SpaceCenter.Vessel.OrbitalReferenceFrame).</param>
+Returns: A vector whose direction is the direction of the maneuver node burn, and
+magnitude is the delta-v of the burn in meters per second.
+
+ Changes as the maneuver node is executed. See [M:SpaceCenter.Node.BurnVector](M:SpaceCenter.Node.BurnVector).
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2876,7 +4493,7 @@ Removes the maneuver node.
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
 
 Returns **void** 
 
@@ -2884,14 +4501,15 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-Returns the position vector of the maneuver node in the given reference frame.
- <param name="referenceFrame">
- </param>
+The position vector of the maneuver node in the given reference frame.
+Returns: The position as a vector.
+<param name="referenceFrame">The reference frame that the returned
+position vector is in.</param>
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2899,14 +4517,15 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Returns the unit direction vector of the maneuver nodes burn in the given reference frame.
- <param name="referenceFrame">
- </param>
+The direction of the maneuver nodes burn.
+Returns: The direction as a unit vector.
+<param name="referenceFrame">The reference frame that the returned
+direction is in.</param>
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2914,11 +4533,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The magnitude of the maneuver nodes delta-v in the prograde direction, in meters per second.
+The magnitude of the maneuver nodes delta-v in the prograde direction,
+in meters per second.
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2926,11 +4546,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The magnitude of the maneuver nodes delta-v in the prograde direction, in meters per second.
+The magnitude of the maneuver nodes delta-v in the prograde direction,
+in meters per second.
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -2939,11 +4560,12 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-The magnitude of the maneuver nodes delta-v in the normal direction, in meters per second.
+The magnitude of the maneuver nodes delta-v in the normal direction,
+in meters per second.
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2951,11 +4573,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The magnitude of the maneuver nodes delta-v in the normal direction, in meters per second.
+The magnitude of the maneuver nodes delta-v in the normal direction,
+in meters per second.
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -2964,11 +4587,12 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-The magnitude of the maneuver nodes delta-v in the radial direction, in meters per second.
+The magnitude of the maneuver nodes delta-v in the radial direction,
+in meters per second.
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -2976,11 +4600,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The magnitude of the maneuver nodes delta-v in the radial direction, in meters per second.
+The magnitude of the maneuver nodes delta-v in the radial direction,
+in meters per second.
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -2990,11 +4615,11 @@ Returns **void**
 **Extends SpaceCenter**
 
 The delta-v of the maneuver node, in meters per second.
-Does not change when executing the maneuver node. See [M:SpaceCenter.Node.RemainingDeltaV](M:SpaceCenter.Node.RemainingDeltaV).
+ Does not change when executing the maneuver node. See [M:SpaceCenter.Node.RemainingDeltaV](M:SpaceCenter.Node.RemainingDeltaV).
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3003,11 +4628,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The delta-v of the maneuver node, in meters per second.
-Does not change when executing the maneuver node. See [M:SpaceCenter.Node.RemainingDeltaV](M:SpaceCenter.Node.RemainingDeltaV).
+ Does not change when executing the maneuver node. See [M:SpaceCenter.Node.RemainingDeltaV](M:SpaceCenter.Node.RemainingDeltaV).
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -3016,12 +4641,12 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-Gets the remaining delta-v of the maneuver node, in meters per second. Changes as the node
-is executed. This is equivalent to the delta-v reported in-game.
+Gets the remaining delta-v of the maneuver node, in meters per second. Changes as the
+node is executed. This is equivalent to the delta-v reported in-game.
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3033,7 +4658,7 @@ The universal time at which the maneuver will occur, in seconds.
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3045,7 +4670,7 @@ The universal time at which the maneuver will occur, in seconds.
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -3058,7 +4683,7 @@ The time until the maneuver node will be encountered, in seconds.
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3070,7 +4695,7 @@ The orbit that results from executing the maneuver node.
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3078,12 +4703,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Gets the reference frame that is fixed relative to the maneuver node's burn.
+The reference frame that is fixed relative to the maneuver node's burn.
 <list type="bullet"><item><description>The origin is at the position of the maneuver node.</description></item><item><description>The y-axis points in the direction of the burn.</description></item><item><description>The x-axis and z-axis point in arbitrary but fixed directions.</description></item></list>
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3091,7 +4716,7 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Gets the reference frame that is fixed relative to the maneuver node, and
+The reference frame that is fixed relative to the maneuver node, and
 orientated with the orbital prograde/normal/radial directions of the
 original orbit at the maneuver node's position.
 <list type="bullet"><item><description>The origin is at the position of the maneuver node.</description></item><item><description>The x-axis points in the orbital anti-radial direction of the original
@@ -3101,7 +4726,7 @@ at the position of the maneuver node.</description></item></list>
 
 **Parameters**
 
--   `node` **Long** A long value representing the id for the SpaceCenter.Node see [Long.js]<https://www.npmjs.com/package/long>
+-   `node` **Long** A long value representing the id for the SpaceCenter.Node
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3109,14 +4734,16 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The unit direction vector that is normal to the orbits reference plane, in the given
-reference frame. The reference plane is the plane from which the orbits inclination is measured.
- <param name="referenceFrame">
- </param>
+The direction that is normal to the orbits reference plane,
+in the given reference frame.
+The reference plane is the plane from which the orbits inclination is measured.
+Returns: The direction as a unit vector.
+<param name="referenceFrame">The reference frame that the returned
+direction is in.</param>
 
 **Parameters**
 
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3124,14 +4751,28 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The unit direction vector from which the orbits longitude of ascending node is measured,
+The direction from which the orbits longitude of ascending node is measured,
 in the given reference frame.
- <param name="referenceFrame">
- </param>
+Returns: The direction as a unit vector.
+<param name="referenceFrame">The reference frame that the returned
+direction is in.</param>
 
 **Parameters**
 
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## orbitMeanAnomalyAtUt
+
+**Extends SpaceCenter**
+
+The mean anomaly at the given time.
+
+**Parameters**
+
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
+-   `ut` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The universal time in seconds.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3143,7 +4784,7 @@ The orbital radius at the point in the orbit given by the true anomaly.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 -   `trueAnomaly` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The true anomaly.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -3156,7 +4797,7 @@ The true anomaly at the given orbital radius.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 -   `radius` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The orbital radius in meters.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -3169,7 +4810,7 @@ The true anomaly at the given time.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 -   `ut` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The universal time in seconds.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -3182,7 +4823,7 @@ The universal time, in seconds, corresponding to the given true anomaly.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 -   `trueAnomaly` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** True anomaly.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -3195,7 +4836,7 @@ The eccentric anomaly at the given universal time.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 -   `ut` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The universal time, in seconds.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -3208,8 +4849,123 @@ The orbital speed at the given time, in meters per second.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 -   `time` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Time from now, in seconds.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## orbitRadiusAt
+
+**Extends SpaceCenter**
+
+The orbital radius at the given time, in meters.
+
+**Parameters**
+
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
+-   `ut` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The universal time to measure the radius at.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## orbitPositionAt
+
+**Extends SpaceCenter**
+
+The position at a given time, in the specified reference frame.
+Returns: The position as a vector.
+
+<param name="referenceFrame">The reference frame that the returned
+position vector is in.</param>
+
+**Parameters**
+
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
+-   `ut` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The universal time to measure the position at.
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## orbitTimeOfClosestApproach
+
+**Extends SpaceCenter**
+
+Estimates and returns the time at closest approach to a target vessel.
+Returns: The universal time at closest approach, in seconds.
+
+**Parameters**
+
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
+-   `target` **Long** A long value representing the id for the SpaceCenter.Vessel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## orbitDistanceAtClosestApproach
+
+**Extends SpaceCenter**
+
+Estimates and returns the distance at closest approach to a target vessel, in meters.
+
+**Parameters**
+
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
+-   `target` **Long** A long value representing the id for the SpaceCenter.Vessel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## orbitListClosestApproaches
+
+**Extends SpaceCenter**
+
+Returns the times at closest approach and corresponding distances, to a target vessel.
+Returns: 
+A list of two lists.
+The first is a list of times at closest approach, as universal times in seconds.
+The second is a list of corresponding distances at closest approach, in meters.
+
+**Parameters**
+
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
+-   `target` **Long** A long value representing the id for the SpaceCenter.Vessel
+-   `orbits` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The number of future orbits to search.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## orbitTrueAnomalyAtAn
+
+**Extends SpaceCenter**
+
+The true anomaly of the ascending node with the given target vessel.
+
+**Parameters**
+
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
+-   `target` **Long** A long value representing the id for the SpaceCenter.Vessel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## orbitTrueAnomalyAtDn
+
+**Extends SpaceCenter**
+
+The true anomaly of the descending node with the given target vessel.
+
+**Parameters**
+
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
+-   `target` **Long** A long value representing the id for the SpaceCenter.Vessel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## orbitRelativeInclination
+
+**Extends SpaceCenter**
+
+Relative inclination of this orbit and the orbit of the given target vessel, in radians.
+
+**Parameters**
+
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
+-   `target` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3221,7 +4977,7 @@ The celestial body (e.g. planet or moon) around which the object is orbiting.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3229,12 +4985,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Gets the apoapsis of the orbit, in meters, from the center of mass of the body being orbited.
-For the apoapsis altitude reported on the in-game map view, use [M:SpaceCenter.Orbit.ApoapsisAltitude](M:SpaceCenter.Orbit.ApoapsisAltitude).
+Gets the apoapsis of the orbit, in meters, from the center of mass
+of the body being orbited.
+ For the apoapsis altitude reported on the in-game map view,
+use [M:SpaceCenter.Orbit.ApoapsisAltitude](M:SpaceCenter.Orbit.ApoapsisAltitude).
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3242,12 +5000,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The periapsis of the orbit, in meters, from the center of mass of the body being orbited.
-For the periapsis altitude reported on the in-game map view, use [M:SpaceCenter.Orbit.PeriapsisAltitude](M:SpaceCenter.Orbit.PeriapsisAltitude).
+The periapsis of the orbit, in meters, from the center of mass
+of the body being orbited.
+ For the periapsis altitude reported on the in-game map view,
+use [M:SpaceCenter.Orbit.PeriapsisAltitude](M:SpaceCenter.Orbit.PeriapsisAltitude).
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3256,11 +5016,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The apoapsis of the orbit, in meters, above the sea level of the body being orbited.
-This is equal to [M:SpaceCenter.Orbit.Apoapsis](M:SpaceCenter.Orbit.Apoapsis) minus the equatorial radius of the body.
+ This is equal to [M:SpaceCenter.Orbit.Apoapsis](M:SpaceCenter.Orbit.Apoapsis) minus the equatorial radius of the body.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3269,11 +5029,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The periapsis of the orbit, in meters, above the sea level of the body being orbited.
-This is equal to [M:SpaceCenter.Orbit.Periapsis](M:SpaceCenter.Orbit.Periapsis) minus the equatorial radius of the body.
+ This is equal to [M:SpaceCenter.Orbit.Periapsis](M:SpaceCenter.Orbit.Periapsis) minus the equatorial radius of the body.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3285,7 +5045,7 @@ The semi-major axis of the orbit, in meters.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3297,7 +5057,7 @@ The semi-minor axis of the orbit, in meters.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3306,12 +5066,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The current radius of the orbit, in meters. This is the distance between the center
-of mass of the object in orbit, and the center of mass of the body around which it is orbiting.
-This value will change over time if the orbit is elliptical.
+of mass of the object in orbit, and the center of mass of the body around which it
+is orbiting.
+ This value will change over time if the orbit is elliptical.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3320,11 +5081,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The current orbital speed of the object in meters per second.
-This value will change over time if the orbit is elliptical.
+ This value will change over time if the orbit is elliptical.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3336,7 +5097,7 @@ The orbital period, in seconds.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3348,7 +5109,7 @@ The time until the object reaches apoapsis, in seconds.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3360,7 +5121,7 @@ The time until the object reaches periapsis, in seconds.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3368,11 +5129,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The <a href="https://en.wikipedia.org/wiki/Orbital_eccentricity">eccentricity</a> of the orbit.
+The <a href="https://en.wikipedia.org/wiki/Orbital_eccentricity">eccentricity</a>
+of the orbit.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3380,12 +5142,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The <a href="https://en.wikipedia.org/wiki/Orbital_inclination">inclination</a> of the orbit,
+The <a href="https://en.wikipedia.org/wiki/Orbital_inclination">inclination</a>
+of the orbit,
 in radians.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3393,12 +5156,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The <a href="https://en.wikipedia.org/wiki/Longitude_of_the_ascending_node">longitude of the
-ascending node</a>, in radians.
+The <a href="https://en.wikipedia.org/wiki/Longitude_of_the_ascending_node">longitude of
+the ascending node</a>, in radians.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3406,11 +5169,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The <a href="https://en.wikipedia.org/wiki/Argument_of_periapsis">argument of periapsis</a>, in radians.
+The <a href="https://en.wikipedia.org/wiki/Argument_of_periapsis">argument of
+periapsis</a>, in radians.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3422,7 +5186,7 @@ The <a href="https://en.wikipedia.org/wiki/Mean_anomaly">mean anomaly at epoch</
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3431,11 +5195,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The time since the epoch (the point at which the
-<a href="https://en.wikipedia.org/wiki/Mean_anomaly">mean anomaly at epoch</a> was measured, in seconds.
+<a href="https://en.wikipedia.org/wiki/Mean_anomaly">mean anomaly at epoch</a>
+was measured, in seconds.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3447,7 +5212,7 @@ The <a href="https://en.wikipedia.org/wiki/Mean_anomaly">mean anomaly</a>.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3459,7 +5224,7 @@ The <a href="https://en.wikipedia.org/wiki/Eccentric_anomaly">eccentric anomaly<
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3471,7 +5236,7 @@ The <a href="https://en.wikipedia.org/wiki/True_anomaly">true anomaly</a>.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3479,12 +5244,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-If the object is going to change sphere of influence in the future, returns the new orbit
-after the change. Otherwise returns <c>null</c>.
+If the object is going to change sphere of influence in the future, returns the new
+orbit after the change. Otherwise returns null.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3492,12 +5257,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The time until the object changes sphere of influence, in seconds. Returns <c>NaN</c> if the
-object is not going to change sphere of influence.
+The time until the object changes sphere of influence, in seconds. Returns NaN
+if the object is not going to change sphere of influence.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3509,7 +5274,206 @@ The current orbital speed in meters per second.
 
 **Parameters**
 
--   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit see [Long.js]<https://www.npmjs.com/package/long>
+-   `orbit` **Long** A long value representing the id for the SpaceCenter.Orbit
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## antennaTransmit
+
+**Extends SpaceCenter**
+
+Transmit data.
+
+**Parameters**
+
+-   `antenna` **Long** A long value representing the id for the SpaceCenter.Antenna
+
+Returns **void** 
+
+## antennaCancel
+
+**Extends SpaceCenter**
+
+Cancel current transmission of data.
+
+**Parameters**
+
+-   `antenna` **Long** A long value representing the id for the SpaceCenter.Antenna
+
+Returns **void** 
+
+## antennaGetPart
+
+**Extends SpaceCenter**
+
+The part object for this antenna.
+
+**Parameters**
+
+-   `antenna` **Long** A long value representing the id for the SpaceCenter.Antenna
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## antennaGetState
+
+**Extends SpaceCenter**
+
+The current state of the antenna.
+
+**Parameters**
+
+-   `antenna` **Long** A long value representing the id for the SpaceCenter.Antenna
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## antennaGetDeployable
+
+**Extends SpaceCenter**
+
+Whether the antenna is deployable.
+
+**Parameters**
+
+-   `antenna` **Long** A long value representing the id for the SpaceCenter.Antenna
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## antennaGetDeployed
+
+**Extends SpaceCenter**
+
+Whether the antenna is deployed.
+ Fixed antennas are always deployed.
+Returns an error if you try to deploy a fixed antenna.
+
+**Parameters**
+
+-   `antenna` **Long** A long value representing the id for the SpaceCenter.Antenna
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## antennaSetDeployed
+
+**Extends SpaceCenter**
+
+Whether the antenna is deployed.
+ Fixed antennas are always deployed.
+Returns an error if you try to deploy a fixed antenna.
+
+**Parameters**
+
+-   `antenna` **Long** A long value representing the id for the SpaceCenter.Antenna
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## antennaGetCanTransmit
+
+**Extends SpaceCenter**
+
+Whether data can be transmitted by this antenna.
+
+**Parameters**
+
+-   `antenna` **Long** A long value representing the id for the SpaceCenter.Antenna
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## antennaGetAllowPartial
+
+**Extends SpaceCenter**
+
+Whether partial data transmission is permitted.
+
+**Parameters**
+
+-   `antenna` **Long** A long value representing the id for the SpaceCenter.Antenna
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## antennaSetAllowPartial
+
+**Extends SpaceCenter**
+
+Whether partial data transmission is permitted.
+
+**Parameters**
+
+-   `antenna` **Long** A long value representing the id for the SpaceCenter.Antenna
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## antennaGetPower
+
+**Extends SpaceCenter**
+
+The power of the antenna.
+
+**Parameters**
+
+-   `antenna` **Long** A long value representing the id for the SpaceCenter.Antenna
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## antennaGetCombinable
+
+**Extends SpaceCenter**
+
+Whether the antenna can be combined with other antennae on the vessel
+to boost the power.
+
+**Parameters**
+
+-   `antenna` **Long** A long value representing the id for the SpaceCenter.Antenna
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## antennaGetCombinableExponent
+
+**Extends SpaceCenter**
+
+Exponent used to calculate the combined power of multiple antennae on a vessel.
+
+**Parameters**
+
+-   `antenna` **Long** A long value representing the id for the SpaceCenter.Antenna
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## antennaGetPacketInterval
+
+**Extends SpaceCenter**
+
+Interval between sending packets in seconds.
+
+**Parameters**
+
+-   `antenna` **Long** A long value representing the id for the SpaceCenter.Antenna
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## antennaGetPacketSize
+
+**Extends SpaceCenter**
+
+Amount of data sent per packet in Mits.
+
+**Parameters**
+
+-   `antenna` **Long** A long value representing the id for the SpaceCenter.Antenna
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## antennaGetPacketResourceCost
+
+**Extends SpaceCenter**
+
+Units of electric charge consumed per packet sent.
+
+**Parameters**
+
+-   `antenna` **Long** A long value representing the id for the SpaceCenter.Antenna
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3521,7 +5485,7 @@ The part object for this cargo bay.
 
 **Parameters**
 
--   `cargoBay` **Long** A long value representing the id for the SpaceCenter.CargoBay see [Long.js]<https://www.npmjs.com/package/long>
+-   `cargoBay` **Long** A long value representing the id for the SpaceCenter.CargoBay
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3533,7 +5497,7 @@ The state of the cargo bay.
 
 **Parameters**
 
--   `cargoBay` **Long** A long value representing the id for the SpaceCenter.CargoBay see [Long.js]<https://www.npmjs.com/package/long>
+-   `cargoBay` **Long** A long value representing the id for the SpaceCenter.CargoBay
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3545,7 +5509,7 @@ Whether the cargo bay is open.
 
 **Parameters**
 
--   `cargoBay` **Long** A long value representing the id for the SpaceCenter.CargoBay see [Long.js]<https://www.npmjs.com/package/long>
+-   `cargoBay` **Long** A long value representing the id for the SpaceCenter.CargoBay
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3557,7 +5521,7 @@ Whether the cargo bay is open.
 
 **Parameters**
 
--   `cargoBay` **Long** A long value representing the id for the SpaceCenter.CargoBay see [Long.js]<https://www.npmjs.com/package/long>
+-   `cargoBay` **Long** A long value representing the id for the SpaceCenter.CargoBay
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -3570,7 +5534,7 @@ The part object for this control surface.
 
 **Parameters**
 
--   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface see [Long.js]<https://www.npmjs.com/package/long>
+-   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3582,7 +5546,7 @@ Whether the control surface has pitch control enabled.
 
 **Parameters**
 
--   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface see [Long.js]<https://www.npmjs.com/package/long>
+-   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3594,7 +5558,7 @@ Whether the control surface has pitch control enabled.
 
 **Parameters**
 
--   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface see [Long.js]<https://www.npmjs.com/package/long>
+-   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -3607,7 +5571,7 @@ Whether the control surface has yaw control enabled.
 
 **Parameters**
 
--   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface see [Long.js]<https://www.npmjs.com/package/long>
+-   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3619,7 +5583,7 @@ Whether the control surface has yaw control enabled.
 
 **Parameters**
 
--   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface see [Long.js]<https://www.npmjs.com/package/long>
+-   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -3632,7 +5596,7 @@ Whether the control surface has roll control enabled.
 
 **Parameters**
 
--   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface see [Long.js]<https://www.npmjs.com/package/long>
+-   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3644,8 +5608,35 @@ Whether the control surface has roll control enabled.
 
 **Parameters**
 
--   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface see [Long.js]<https://www.npmjs.com/package/long>
+-   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## controlSurfaceGetAuthorityLimiter
+
+**Extends SpaceCenter**
+
+The authority limiter for the control surface, which controls how far the
+control surface will move.
+
+**Parameters**
+
+-   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## controlSurfaceSetAuthorityLimiter
+
+**Extends SpaceCenter**
+
+The authority limiter for the control surface, which controls how far the
+control surface will move.
+
+**Parameters**
+
+-   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface
+-   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
 
@@ -3657,7 +5648,7 @@ Whether the control surface movement is inverted.
 
 **Parameters**
 
--   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface see [Long.js]<https://www.npmjs.com/package/long>
+-   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3669,7 +5660,7 @@ Whether the control surface movement is inverted.
 
 **Parameters**
 
--   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface see [Long.js]<https://www.npmjs.com/package/long>
+-   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -3682,7 +5673,7 @@ Whether the control surface has been fully deployed.
 
 **Parameters**
 
--   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface see [Long.js]<https://www.npmjs.com/package/long>
+-   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3694,7 +5685,7 @@ Whether the control surface has been fully deployed.
 
 **Parameters**
 
--   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface see [Long.js]<https://www.npmjs.com/package/long>
+-   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -3707,7 +5698,7 @@ Surface area of the control surface in <math>m^2</math>.
 
 **Parameters**
 
--   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface see [Long.js]<https://www.npmjs.com/package/long>
+-   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3715,12 +5706,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The available torque in the pitch, roll and yaw axes of the vessel, in Newton meters.
-These axes correspond to the coordinate axes of the [M:SpaceCenter.Vessel.ReferenceFrame](M:SpaceCenter.Vessel.ReferenceFrame).
+The available torque, in Newton meters, that can be produced by this control surface,
+in the positive and negative pitch, roll and yaw axes of the vessel. These axes
+correspond to the coordinate axes of the [M:SpaceCenter.Vessel.ReferenceFrame](M:SpaceCenter.Vessel.ReferenceFrame).
 
 **Parameters**
 
--   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface see [Long.js]<https://www.npmjs.com/package/long>
+-   `controlSurface` **Long** A long value representing the id for the SpaceCenter.ControlSurface
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3730,10 +5722,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 Fires the decoupler. Returns the new vessel created when the decoupler fires.
 Throws an exception if the decoupler has already fired.
+ When called, the active vessel may change. It is therefore possible that,
+after calling this function, the object(s) returned by previous call(s) to
+[M:SpaceCenter.ActiveVessel](M:SpaceCenter.ActiveVessel) no longer refer to the active vessel.
 
 **Parameters**
 
--   `decoupler` **Long** A long value representing the id for the SpaceCenter.Decoupler see [Long.js]<https://www.npmjs.com/package/long>
+-   `decoupler` **Long** A long value representing the id for the SpaceCenter.Decoupler
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3745,7 +5740,7 @@ The part object for this decoupler.
 
 **Parameters**
 
--   `decoupler` **Long** A long value representing the id for the SpaceCenter.Decoupler see [Long.js]<https://www.npmjs.com/package/long>
+-   `decoupler` **Long** A long value representing the id for the SpaceCenter.Decoupler
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3757,7 +5752,7 @@ Whether the decoupler has fired.
 
 **Parameters**
 
--   `decoupler` **Long** A long value representing the id for the SpaceCenter.Decoupler see [Long.js]<https://www.npmjs.com/package/long>
+-   `decoupler` **Long** A long value representing the id for the SpaceCenter.Decoupler
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3769,7 +5764,7 @@ Whether the decoupler is enabled in the staging sequence.
 
 **Parameters**
 
--   `decoupler` **Long** A long value representing the id for the SpaceCenter.Decoupler see [Long.js]<https://www.npmjs.com/package/long>
+-   `decoupler` **Long** A long value representing the id for the SpaceCenter.Decoupler
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3781,7 +5776,7 @@ The impulse that the decoupler imparts when it is fired, in Newton seconds.
 
 **Parameters**
 
--   `decoupler` **Long** A long value representing the id for the SpaceCenter.Decoupler see [Long.js]<https://www.npmjs.com/package/long>
+-   `decoupler` **Long** A long value representing the id for the SpaceCenter.Decoupler
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3792,11 +5787,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 Undocks the docking port and returns the new [T:SpaceCenter.Vessel](T:SpaceCenter.Vessel) that is created.
 This method can be called for either docking port in a docked pair.
 Throws an exception if the docking port is not docked to anything.
-After undocking, the active vessel may change. See [M:SpaceCenter.ActiveVessel](M:SpaceCenter.ActiveVessel).
+ When called, the active vessel may change. It is therefore possible that,
+after calling this function, the object(s) returned by previous call(s) to
+[M:SpaceCenter.ActiveVessel](M:SpaceCenter.ActiveVessel) no longer refer to the active vessel.
 
 **Parameters**
 
--   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort see [Long.js]<https://www.npmjs.com/package/long>
+-   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3804,12 +5801,15 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The position of the docking port in the given reference frame.
+The position of the docking port, in the given reference frame.
+Returns: The position as a vector.
+<param name="referenceFrame">The reference frame that the returned
+position vector is in.</param>
 
 **Parameters**
 
--   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3818,11 +5818,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The direction that docking port points in, in the given reference frame.
+Returns: The direction as a unit vector.
+<param name="referenceFrame">The reference frame that the returned
+direction is in.</param>
 
 **Parameters**
 
--   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3831,11 +5834,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The rotation of the docking port, in the given reference frame.
+Returns: The rotation as a quaternion of the form <math>(x, y, z, w)</math>.
+<param name="referenceFrame">The reference frame that the returned
+rotation is in.</param>
 
 **Parameters**
 
--   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3847,7 +5853,7 @@ The part object for this docking port.
 
 **Parameters**
 
--   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort see [Long.js]<https://www.npmjs.com/package/long>
+-   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3859,7 +5865,7 @@ The current state of the docking port.
 
 **Parameters**
 
--   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort see [Long.js]<https://www.npmjs.com/package/long>
+-   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3867,12 +5873,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The part that this docking port is docked to. Returns <c>null</c> if this
+The part that this docking port is docked to. Returns null if this
 docking port is not docked to anything.
 
 **Parameters**
 
--   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort see [Long.js]<https://www.npmjs.com/package/long>
+-   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3885,7 +5891,7 @@ becomes ready to dock with another port, in meters.
 
 **Parameters**
 
--   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort see [Long.js]<https://www.npmjs.com/package/long>
+-   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3897,7 +5903,7 @@ Whether the docking port has a shield.
 
 **Parameters**
 
--   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort see [Long.js]<https://www.npmjs.com/package/long>
+-   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3906,14 +5912,15 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The state of the docking ports shield, if it has one.
-Returns <c>true</c> if the docking port has a shield, and the shield is
-closed. Otherwise returns <c>false</c>. When set to <c>true</c>, the shield is
-closed, and when set to <c>false</c> the shield is opened. If the docking
+
+Returns true if the docking port has a shield, and the shield is
+closed. Otherwise returns false. When set to true, the shield is
+closed, and when set to false the shield is opened. If the docking
 port does not have a shield, setting this attribute has no effect.
 
 **Parameters**
 
--   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort see [Long.js]<https://www.npmjs.com/package/long>
+-   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3922,14 +5929,15 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The state of the docking ports shield, if it has one.
-Returns <c>true</c> if the docking port has a shield, and the shield is
-closed. Otherwise returns <c>false</c>. When set to <c>true</c>, the shield is
-closed, and when set to <c>false</c> the shield is opened. If the docking
+
+Returns true if the docking port has a shield, and the shield is
+closed. Otherwise returns false. When set to true, the shield is
+closed, and when set to false the shield is opened. If the docking
 port does not have a shield, setting this attribute has no effect.
 
 **Parameters**
 
--   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort see [Long.js]<https://www.npmjs.com/package/long>
+-   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -3940,12 +5948,17 @@ Returns **void**
 
 The reference frame that is fixed relative to this docking port, and
 oriented with the port.
-<list type="bullet"><item><description>The origin is at the position of the docking port.</description></item><item><description>The axes rotate with the docking port.</description></item><item><description>The x-axis points out to the right side of the docking port.</description></item><item><description>The y-axis points in the direction the docking port is facing.</description></item><item><description>The z-axis points out of the bottom off the docking port.</description></item></list> This reference frame is not necessarily equivalent to the reference frame
+<list type="bullet"><item><description>The origin is at the position of the docking port.
+</description></item><item><description>The axes rotate with the docking port.</description></item><item><description>The x-axis points out to the right side of the docking port.
+</description></item><item><description>The y-axis points in the direction the docking port is facing.
+</description></item><item><description>The z-axis points out of the bottom off the docking port.
+</description></item></list><remarks>
+This reference frame is not necessarily equivalent to the reference frame
 for the part, returned by [M:SpaceCenter.Part.ReferenceFrame](M:SpaceCenter.Part.ReferenceFrame).
 
 **Parameters**
 
--   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort see [Long.js]<https://www.npmjs.com/package/long>
+-   `dockingPort` **Long** A long value representing the id for the SpaceCenter.DockingPort
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3957,7 +5970,7 @@ Toggle the current engine mode.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **void** 
 
@@ -3969,7 +5982,7 @@ The part object for this engine.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3982,7 +5995,7 @@ depending on [M:SpaceCenter.Engine.CanShutdown](M:SpaceCenter.Engine.CanShutdown
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -3995,7 +6008,7 @@ depending on [M:SpaceCenter.Engine.CanShutdown](M:SpaceCenter.Engine.CanShutdown
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -4008,7 +6021,7 @@ The current amount of thrust being produced by the engine, in Newtons.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4019,11 +6032,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 The amount of thrust, in Newtons, that would be produced by the engine
 when activated and with its throttle set to 100%.
 Returns zero if the engine does not have any fuel.
-Takes the engine's current [M:SpaceCenter.Engine.ThrustLimit](M:SpaceCenter.Engine.ThrustLimit) and atmospheric conditions into account.
+Takes the engine's current [M:SpaceCenter.Engine.ThrustLimit](M:SpaceCenter.Engine.ThrustLimit) and atmospheric conditions
+into account.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4036,7 +6050,7 @@ when activated and fueled, with its throttle and throttle limiter set to 100%.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4051,7 +6065,7 @@ vessel's throttle is set to 100% and the engine is in a vacuum.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4065,7 +6079,7 @@ rocket booster cannot be changed in flight.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4079,7 +6093,7 @@ rocket booster cannot be changed in flight.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -4089,14 +6103,14 @@ Returns **void**
 **Extends SpaceCenter**
 
 The components of the engine that generate thrust.
-For example, this corresponds to the rocket nozzel on a solid rocket booster,
+ For example, this corresponds to the rocket nozzel on a solid rocket booster,
 or the individual nozzels on a RAPIER engine.
 The overall thrust produced by the engine, as reported by [M:SpaceCenter.Engine.AvailableThrust](M:SpaceCenter.Engine.AvailableThrust),
 [M:SpaceCenter.Engine.MaxThrust](M:SpaceCenter.Engine.MaxThrust) and others, is the sum of the thrust generated by each thruster.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4109,7 +6123,7 @@ if the engine is not active.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4121,7 +6135,7 @@ The vacuum specific impulse of the engine, in seconds.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4133,7 +6147,7 @@ The specific impulse of the engine at sea level on Kerbin, in seconds.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4145,7 +6159,7 @@ The names of the propellants that the engine consumes.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4157,7 +6171,7 @@ The propellants that the engine consumes.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4167,12 +6181,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 The ratio of resources that the engine consumes. A dictionary mapping resource names
 to the ratio at which they are consumed by the engine.
-For example, if the ratios are 0.6 for LiquidFuel and 0.4 for Oxidizer, then for every 0.6 units of
-LiquidFuel that the engine burns, it will burn 0.4 units of Oxidizer.
+ For example, if the ratios are 0.6 for LiquidFuel and 0.4 for Oxidizer, then for every
+0.6 units of LiquidFuel that the engine burns, it will burn 0.4 units of Oxidizer.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4181,11 +6195,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Whether the engine has any fuel available.
-The engine must be activated for this property to update correctly.
+ The engine must be activated for this property to update correctly.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4200,7 +6214,7 @@ setting, as some engines take time to adjust their throttle
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4209,12 +6223,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Whether the [M:SpaceCenter.Control.Throttle](M:SpaceCenter.Control.Throttle) affects the engine. For example,
-this is <c>true</c> for liquid fueled rockets, and <c>false</c> for solid rocket
+this is true for liquid fueled rockets, and false for solid rocket
 boosters.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4223,12 +6237,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Whether the engine can be restarted once shutdown. If the engine cannot be shutdown,
-returns <c>false</c>. For example, this is <c>true</c> for liquid fueled rockets
-and <c>false</c> for solid rocket boosters.
+returns false. For example, this is true for liquid fueled rockets
+and false for solid rocket boosters.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4237,11 +6251,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Whether the engine can be shutdown once activated. For example, this is
-<c>true</c> for liquid fueled rockets and <c>false</c> for solid rocket boosters.
+true for liquid fueled rockets and false for solid rocket boosters.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4253,7 +6267,7 @@ Whether the engine has multiple modes of operation.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4265,7 +6279,7 @@ The name of the current engine mode.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4277,7 +6291,7 @@ The name of the current engine mode.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -4291,7 +6305,7 @@ A dictionary mapping mode names to [T:SpaceCenter.Engine](T:SpaceCenter.Engine) 
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4303,7 +6317,7 @@ Whether the engine will automatically switch modes.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4315,7 +6329,7 @@ Whether the engine will automatically switch modes.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -4328,7 +6342,7 @@ Whether the engine is gimballed.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4341,7 +6355,7 @@ Returns 0 if the engine is not gimballed.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4354,7 +6368,7 @@ no effect if the engine is not gimballed.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4367,7 +6381,7 @@ no effect if the engine is not gimballed.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -4381,7 +6395,7 @@ Returns 0 if the gimbal is locked.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4394,7 +6408,7 @@ Returns 0 if the gimbal is locked.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -4403,13 +6417,14 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-The available torque in the pitch, roll and yaw axes of the vessel, in Newton meters.
-These axes correspond to the coordinate axes of the [M:SpaceCenter.Vessel.ReferenceFrame](M:SpaceCenter.Vessel.ReferenceFrame).
+The available torque, in Newton meters, that can be produced by this engine,
+in the positive and negative pitch, roll and yaw axes of the vessel. These axes
+correspond to the coordinate axes of the [M:SpaceCenter.Vessel.ReferenceFrame](M:SpaceCenter.Vessel.ReferenceFrame).
 Returns zero if the engine is inactive, or not gimballed.
 
 **Parameters**
 
--   `engine` **Long** A long value representing the id for the SpaceCenter.Engine see [Long.js]<https://www.npmjs.com/package/long>
+-   `engine` **Long** A long value representing the id for the SpaceCenter.Engine
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4421,7 +6436,7 @@ Run the experiment.
 
 **Parameters**
 
--   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment see [Long.js]<https://www.npmjs.com/package/long>
+-   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment
 
 Returns **void** 
 
@@ -4433,7 +6448,7 @@ Transmit all experimental data contained by this part.
 
 **Parameters**
 
--   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment see [Long.js]<https://www.npmjs.com/package/long>
+-   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment
 
 Returns **void** 
 
@@ -4445,7 +6460,7 @@ Dump the experimental data contained by the experiment.
 
 **Parameters**
 
--   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment see [Long.js]<https://www.npmjs.com/package/long>
+-   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment
 
 Returns **void** 
 
@@ -4457,7 +6472,7 @@ Reset the experiment.
 
 **Parameters**
 
--   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment see [Long.js]<https://www.npmjs.com/package/long>
+-   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment
 
 Returns **void** 
 
@@ -4469,7 +6484,7 @@ The part object for this experiment.
 
 **Parameters**
 
--   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment see [Long.js]<https://www.npmjs.com/package/long>
+-   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4481,7 +6496,7 @@ Whether the experiment is inoperable.
 
 **Parameters**
 
--   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment see [Long.js]<https://www.npmjs.com/package/long>
+-   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4493,7 +6508,7 @@ Whether the experiment has been deployed.
 
 **Parameters**
 
--   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment see [Long.js]<https://www.npmjs.com/package/long>
+-   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4505,7 +6520,7 @@ Whether the experiment can be re-run.
 
 **Parameters**
 
--   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment see [Long.js]<https://www.npmjs.com/package/long>
+-   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4517,7 +6532,7 @@ Whether the experiment contains data.
 
 **Parameters**
 
--   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment see [Long.js]<https://www.npmjs.com/package/long>
+-   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4529,7 +6544,7 @@ The data contained in this experiment.
 
 **Parameters**
 
--   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment see [Long.js]<https://www.npmjs.com/package/long>
+-   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4541,7 +6556,7 @@ Determines if the experiment is available given the current conditions.
 
 **Parameters**
 
--   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment see [Long.js]<https://www.npmjs.com/package/long>
+-   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4553,7 +6568,7 @@ The name of the biome the experiment is currently in.
 
 **Parameters**
 
--   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment see [Long.js]<https://www.npmjs.com/package/long>
+-   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4561,12 +6576,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Containing information on the corresponding specific science result for the current conditions.
-Returns null if experiment is unavailable.
+Containing information on the corresponding specific science result for the current
+conditions. Returns null if the experiment is unavailable.
 
 **Parameters**
 
--   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment see [Long.js]<https://www.npmjs.com/package/long>
+-   `experiment` **Long** A long value representing the id for the SpaceCenter.Experiment
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4578,7 +6593,7 @@ Jettison the fairing. Has no effect if it has already been jettisoned.
 
 **Parameters**
 
--   `fairing` **Long** A long value representing the id for the SpaceCenter.Fairing see [Long.js]<https://www.npmjs.com/package/long>
+-   `fairing` **Long** A long value representing the id for the SpaceCenter.Fairing
 
 Returns **void** 
 
@@ -4590,7 +6605,7 @@ The part object for this fairing.
 
 **Parameters**
 
--   `fairing` **Long** A long value representing the id for the SpaceCenter.Fairing see [Long.js]<https://www.npmjs.com/package/long>
+-   `fairing` **Long** A long value representing the id for the SpaceCenter.Fairing
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4602,7 +6617,7 @@ Whether the fairing has been jettisoned.
 
 **Parameters**
 
--   `fairing` **Long** A long value representing the id for the SpaceCenter.Fairing see [Long.js]<https://www.npmjs.com/package/long>
+-   `fairing` **Long** A long value representing the id for the SpaceCenter.Fairing
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4614,7 +6629,7 @@ Remove the force.
 
 **Parameters**
 
--   `force` **Long** A long value representing the id for the SpaceCenter.Force see [Long.js]<https://www.npmjs.com/package/long>
+-   `force` **Long** A long value representing the id for the SpaceCenter.Force
 
 Returns **void** 
 
@@ -4626,7 +6641,7 @@ The part that this force is applied to.
 
 **Parameters**
 
--   `force` **Long** A long value representing the id for the SpaceCenter.Force see [Long.js]<https://www.npmjs.com/package/long>
+-   `force` **Long** A long value representing the id for the SpaceCenter.Force
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4634,11 +6649,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The force vector. The magnitude of the vector is the strength of the force in Newtons.
+The force vector, in Newtons.
+Returns: A vector pointing in the direction that the force acts,
+with its magnitude equal to the strength of the force in Newtons.
 
 **Parameters**
 
--   `force` **Long** A long value representing the id for the SpaceCenter.Force see [Long.js]<https://www.npmjs.com/package/long>
+-   `force` **Long** A long value representing the id for the SpaceCenter.Force
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4646,11 +6663,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The force vector. The magnitude of the vector is the strength of the force in Newtons.
+The force vector, in Newtons.
+Returns: A vector pointing in the direction that the force acts,
+with its magnitude equal to the strength of the force in Newtons.
 
 **Parameters**
 
--   `force` **Long** A long value representing the id for the SpaceCenter.Force see [Long.js]<https://www.npmjs.com/package/long>
+-   `force` **Long** A long value representing the id for the SpaceCenter.Force
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -4659,11 +6678,12 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-The position at which the force acts.
+The position at which the force acts, in reference frame [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame).
+Returns: The position as a vector.
 
 **Parameters**
 
--   `force` **Long** A long value representing the id for the SpaceCenter.Force see [Long.js]<https://www.npmjs.com/package/long>
+-   `force` **Long** A long value representing the id for the SpaceCenter.Force
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4671,11 +6691,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The position at which the force acts.
+The position at which the force acts, in reference frame [T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame).
+Returns: The position as a vector.
 
 **Parameters**
 
--   `force` **Long** A long value representing the id for the SpaceCenter.Force see [Long.js]<https://www.npmjs.com/package/long>
+-   `force` **Long** A long value representing the id for the SpaceCenter.Force
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -4688,7 +6709,7 @@ The reference frame of the force vector and position.
 
 **Parameters**
 
--   `force` **Long** A long value representing the id for the SpaceCenter.Force see [Long.js]<https://www.npmjs.com/package/long>
+-   `force` **Long** A long value representing the id for the SpaceCenter.Force
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4700,8 +6721,8 @@ The reference frame of the force vector and position.
 
 **Parameters**
 
--   `force` **Long** A long value representing the id for the SpaceCenter.Force see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `force` **Long** A long value representing the id for the SpaceCenter.Force
+-   `value` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **void** 
 
@@ -4713,7 +6734,7 @@ The part object for this intake.
 
 **Parameters**
 
--   `intake` **Long** A long value representing the id for the SpaceCenter.Intake see [Long.js]<https://www.npmjs.com/package/long>
+-   `intake` **Long** A long value representing the id for the SpaceCenter.Intake
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4725,7 +6746,7 @@ Whether the intake is open.
 
 **Parameters**
 
--   `intake` **Long** A long value representing the id for the SpaceCenter.Intake see [Long.js]<https://www.npmjs.com/package/long>
+-   `intake` **Long** A long value representing the id for the SpaceCenter.Intake
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4737,7 +6758,7 @@ Whether the intake is open.
 
 **Parameters**
 
--   `intake` **Long** A long value representing the id for the SpaceCenter.Intake see [Long.js]<https://www.npmjs.com/package/long>
+-   `intake` **Long** A long value representing the id for the SpaceCenter.Intake
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -4750,7 +6771,7 @@ Speed of the flow into the intake, in <math>m/s</math>.
 
 **Parameters**
 
--   `intake` **Long** A long value representing the id for the SpaceCenter.Intake see [Long.js]<https://www.npmjs.com/package/long>
+-   `intake` **Long** A long value representing the id for the SpaceCenter.Intake
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4762,7 +6783,7 @@ The rate of flow into the intake, in units of resource per second.
 
 **Parameters**
 
--   `intake` **Long** A long value representing the id for the SpaceCenter.Intake see [Long.js]<https://www.npmjs.com/package/long>
+-   `intake` **Long** A long value representing the id for the SpaceCenter.Intake
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4774,128 +6795,9 @@ The area of the intake's opening, in square meters.
 
 **Parameters**
 
--   `intake` **Long** A long value representing the id for the SpaceCenter.Intake see [Long.js]<https://www.npmjs.com/package/long>
+-   `intake` **Long** A long value representing the id for the SpaceCenter.Intake
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
-
-## landingGearGetPart
-
-**Extends SpaceCenter**
-
-The part object for this landing gear.
-
-**Parameters**
-
--   `landingGear` **Long** A long value representing the id for the SpaceCenter.LandingGear see [Long.js]<https://www.npmjs.com/package/long>
-
-Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
-
-## landingGearGetDeployable
-
-**Extends SpaceCenter**
-
-Whether the landing gear is deployable.
-
-**Parameters**
-
--   `landingGear` **Long** A long value representing the id for the SpaceCenter.LandingGear see [Long.js]<https://www.npmjs.com/package/long>
-
-Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
-
-## landingGearGetState
-
-**Extends SpaceCenter**
-
-Gets the current state of the landing gear.
-Fixed landing gear are always deployed.
-
-**Parameters**
-
--   `landingGear` **Long** A long value representing the id for the SpaceCenter.LandingGear see [Long.js]<https://www.npmjs.com/package/long>
-
-Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
-
-## landingGearGetDeployed
-
-**Extends SpaceCenter**
-
-Whether the landing gear is deployed.
-Fixed landing gear are always deployed.
-Returns an error if you try to deploy fixed landing gear.
-
-**Parameters**
-
--   `landingGear` **Long** A long value representing the id for the SpaceCenter.LandingGear see [Long.js]<https://www.npmjs.com/package/long>
-
-Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
-
-## landingGearSetDeployed
-
-**Extends SpaceCenter**
-
-Whether the landing gear is deployed.
-Fixed landing gear are always deployed.
-Returns an error if you try to deploy fixed landing gear.
-
-**Parameters**
-
--   `landingGear` **Long** A long value representing the id for the SpaceCenter.LandingGear see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
-
-Returns **void** 
-
-## landingLegGetPart
-
-**Extends SpaceCenter**
-
-The part object for this landing leg.
-
-**Parameters**
-
--   `landingLeg` **Long** A long value representing the id for the SpaceCenter.LandingLeg see [Long.js]<https://www.npmjs.com/package/long>
-
-Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
-
-## landingLegGetState
-
-**Extends SpaceCenter**
-
-The current state of the landing leg.
-
-**Parameters**
-
--   `landingLeg` **Long** A long value representing the id for the SpaceCenter.LandingLeg see [Long.js]<https://www.npmjs.com/package/long>
-
-Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
-
-## landingLegGetDeployed
-
-**Extends SpaceCenter**
-
-Whether the landing leg is deployed.
-Fixed landing legs are always deployed.
-Returns an error if you try to deploy fixed landing gear.
-
-**Parameters**
-
--   `landingLeg` **Long** A long value representing the id for the SpaceCenter.LandingLeg see [Long.js]<https://www.npmjs.com/package/long>
-
-Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
-
-## landingLegSetDeployed
-
-**Extends SpaceCenter**
-
-Whether the landing leg is deployed.
-Fixed landing legs are always deployed.
-Returns an error if you try to deploy fixed landing gear.
-
-**Parameters**
-
--   `landingLeg` **Long** A long value representing the id for the SpaceCenter.LandingLeg see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
-
-Returns **void** 
 
 ## launchClampRelease
 
@@ -4905,7 +6807,7 @@ Releases the docking clamp. Has no effect if the clamp has already been released
 
 **Parameters**
 
--   `launchClamp` **Long** A long value representing the id for the SpaceCenter.LaunchClamp see [Long.js]<https://www.npmjs.com/package/long>
+-   `launchClamp` **Long** A long value representing the id for the SpaceCenter.LaunchClamp
 
 Returns **void** 
 
@@ -4917,7 +6819,84 @@ The part object for this launch clamp.
 
 **Parameters**
 
--   `launchClamp` **Long** A long value representing the id for the SpaceCenter.LaunchClamp see [Long.js]<https://www.npmjs.com/package/long>
+-   `launchClamp` **Long** A long value representing the id for the SpaceCenter.LaunchClamp
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## legGetPart
+
+**Extends SpaceCenter**
+
+The part object for this landing leg.
+
+**Parameters**
+
+-   `leg` **Long** A long value representing the id for the SpaceCenter.Leg
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## legGetState
+
+**Extends SpaceCenter**
+
+The current state of the landing leg.
+
+**Parameters**
+
+-   `leg` **Long** A long value representing the id for the SpaceCenter.Leg
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## legGetDeployable
+
+**Extends SpaceCenter**
+
+Whether the leg is deployable.
+
+**Parameters**
+
+-   `leg` **Long** A long value representing the id for the SpaceCenter.Leg
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## legGetDeployed
+
+**Extends SpaceCenter**
+
+Whether the landing leg is deployed.
+ Fixed landing legs are always deployed.
+Returns an error if you try to deploy fixed landing gear.
+
+**Parameters**
+
+-   `leg` **Long** A long value representing the id for the SpaceCenter.Leg
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## legSetDeployed
+
+**Extends SpaceCenter**
+
+Whether the landing leg is deployed.
+ Fixed landing legs are always deployed.
+Returns an error if you try to deploy fixed landing gear.
+
+**Parameters**
+
+-   `leg` **Long** A long value representing the id for the SpaceCenter.Leg
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## legGetIsGrounded
+
+**Extends SpaceCenter**
+
+Returns whether the leg is touching the ground.
+
+**Parameters**
+
+-   `leg` **Long** A long value representing the id for the SpaceCenter.Leg
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4929,7 +6908,7 @@ The part object for this light.
 
 **Parameters**
 
--   `light` **Long** A long value representing the id for the SpaceCenter.Light see [Long.js]<https://www.npmjs.com/package/long>
+-   `light` **Long** A long value representing the id for the SpaceCenter.Light
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4941,7 +6920,7 @@ Whether the light is switched on.
 
 **Parameters**
 
--   `light` **Long** A long value representing the id for the SpaceCenter.Light see [Long.js]<https://www.npmjs.com/package/long>
+-   `light` **Long** A long value representing the id for the SpaceCenter.Light
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4953,7 +6932,7 @@ Whether the light is switched on.
 
 **Parameters**
 
--   `light` **Long** A long value representing the id for the SpaceCenter.Light see [Long.js]<https://www.npmjs.com/package/long>
+-   `light` **Long** A long value representing the id for the SpaceCenter.Light
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -4966,7 +6945,7 @@ The color of the light, as an RGB triple.
 
 **Parameters**
 
--   `light` **Long** A long value representing the id for the SpaceCenter.Light see [Long.js]<https://www.npmjs.com/package/long>
+-   `light` **Long** A long value representing the id for the SpaceCenter.Light
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4978,7 +6957,7 @@ The color of the light, as an RGB triple.
 
 **Parameters**
 
--   `light` **Long** A long value representing the id for the SpaceCenter.Light see [Long.js]<https://www.npmjs.com/package/long>
+-   `light` **Long** A long value representing the id for the SpaceCenter.Light
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -4991,7 +6970,7 @@ The current power usage, in units of charge per second.
 
 **Parameters**
 
--   `light` **Long** A long value representing the id for the SpaceCenter.Light see [Long.js]<https://www.npmjs.com/package/long>
+-   `light` **Long** A long value representing the id for the SpaceCenter.Light
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -4999,11 +6978,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Returns <c>true</c> if the module has a field with the given name.
+Returns true if the module has a field with the given name.
 
 **Parameters**
 
--   `module` **Long** A long value representing the id for the SpaceCenter.Module see [Long.js]<https://www.npmjs.com/package/long>
+-   `module` **Long** A long value representing the id for the SpaceCenter.Module
 -   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the field.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -5016,7 +6995,7 @@ Returns the value of a field.
 
 **Parameters**
 
--   `module` **Long** A long value representing the id for the SpaceCenter.Module see [Long.js]<https://www.npmjs.com/package/long>
+-   `module` **Long** A long value representing the id for the SpaceCenter.Module
 -   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the field.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -5029,7 +7008,7 @@ Set the value of a field to the given integer number.
 
 **Parameters**
 
--   `module` **Long** A long value representing the id for the SpaceCenter.Module see [Long.js]<https://www.npmjs.com/package/long>
+-   `module` **Long** A long value representing the id for the SpaceCenter.Module
 -   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the field.
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Value to set.
 
@@ -5043,7 +7022,7 @@ Set the value of a field to the given floating point number.
 
 **Parameters**
 
--   `module` **Long** A long value representing the id for the SpaceCenter.Module see [Long.js]<https://www.npmjs.com/package/long>
+-   `module` **Long** A long value representing the id for the SpaceCenter.Module
 -   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the field.
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Value to set.
 
@@ -5057,7 +7036,7 @@ Set the value of a field to the given string.
 
 **Parameters**
 
--   `module` **Long** A long value representing the id for the SpaceCenter.Module see [Long.js]<https://www.npmjs.com/package/long>
+-   `module` **Long** A long value representing the id for the SpaceCenter.Module
 -   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the field.
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Value to set.
 
@@ -5071,7 +7050,7 @@ Set the value of a field to its original value.
 
 **Parameters**
 
--   `module` **Long** A long value representing the id for the SpaceCenter.Module see [Long.js]<https://www.npmjs.com/package/long>
+-   `module` **Long** A long value representing the id for the SpaceCenter.Module
 -   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the field.
 
 Returns **void** 
@@ -5080,14 +7059,12 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-<c>true</c> if the module has an event with the given name.
-            <param name="name">
- </param>
+<summary>true if the module has an event with the given name.
 
 **Parameters**
 
--   `module` **Long** A long value representing the id for the SpaceCenter.Module see [Long.js]<https://www.npmjs.com/package/long>
--   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** \-
+-   `module` **Long** A long value representing the id for the SpaceCenter.Module
+-   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5095,14 +7072,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Trigger the named event. Equivalent to clicking the button in the right-click menu of the part.
- <param name="name">
- </param>
+Trigger the named event. Equivalent to clicking the button in the right-click menu
+of the part.
 
 **Parameters**
 
--   `module` **Long** A long value representing the id for the SpaceCenter.Module see [Long.js]<https://www.npmjs.com/package/long>
--   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** \-
+-   `module` **Long** A long value representing the id for the SpaceCenter.Module
+-   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
 
@@ -5110,14 +7086,12 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-<c>true</c> if the part has an action with the given name.
-            <param name="name">
- </param>
+<summary>true if the part has an action with the given name.
 
 **Parameters**
 
--   `module` **Long** A long value representing the id for the SpaceCenter.Module see [Long.js]<https://www.npmjs.com/package/long>
--   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** \-
+-   `module` **Long** A long value representing the id for the SpaceCenter.Module
+-   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5126,16 +7100,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Set the value of an action with the given name.
- <param name="name">
- </param>
- <param name="value">
- </param>
 
 **Parameters**
 
--   `module` **Long** A long value representing the id for the SpaceCenter.Module see [Long.js]<https://www.npmjs.com/package/long>
--   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** \-
--   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** \-
+-   `module` **Long** A long value representing the id for the SpaceCenter.Module
+-   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
 
@@ -5147,7 +7117,7 @@ Name of the PartModule. For example, "ModuleEngines".
 
 **Parameters**
 
--   `module` **Long** A long value representing the id for the SpaceCenter.Module see [Long.js]<https://www.npmjs.com/package/long>
+-   `module` **Long** A long value representing the id for the SpaceCenter.Module
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5159,7 +7129,7 @@ The part that contains this module.
 
 **Parameters**
 
--   `module` **Long** A long value representing the id for the SpaceCenter.Module see [Long.js]<https://www.npmjs.com/package/long>
+-   `module` **Long** A long value representing the id for the SpaceCenter.Module
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5172,7 +7142,7 @@ These are the values visible in the right-click menu of the part.
 
 **Parameters**
 
--   `module` **Long** A long value representing the id for the SpaceCenter.Module see [Long.js]<https://www.npmjs.com/package/long>
+-   `module` **Long** A long value representing the id for the SpaceCenter.Module
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5185,7 +7155,7 @@ visible in the right-click menu of the part.
 
 **Parameters**
 
--   `module` **Long** A long value representing the id for the SpaceCenter.Module see [Long.js]<https://www.npmjs.com/package/long>
+-   `module` **Long** A long value representing the id for the SpaceCenter.Module
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5193,12 +7163,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A list of all the names of the modules actions. These are the parts actions that can be assigned
-to action groups in the in-game editor.
+A list of all the names of the modules actions. These are the parts actions that can
+be assigned to action groups in the in-game editor.
 
 **Parameters**
 
--   `module` **Long** A long value representing the id for the SpaceCenter.Module see [Long.js]<https://www.npmjs.com/package/long>
+-   `module` **Long** A long value representing the id for the SpaceCenter.Module
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5211,7 +7181,20 @@ been deployed.
 
 **Parameters**
 
--   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute see [Long.js]<https://www.npmjs.com/package/long>
+-   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute
+
+Returns **void** 
+
+## parachuteArm
+
+**Extends SpaceCenter**
+
+Deploys the parachute. This has no effect if the parachute has already
+been armed or deployed. Only applicable to RealChutes parachutes.
+
+**Parameters**
+
+-   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute
 
 Returns **void** 
 
@@ -5223,7 +7206,7 @@ The part object for this parachute.
 
 **Parameters**
 
--   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute see [Long.js]<https://www.npmjs.com/package/long>
+-   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5235,7 +7218,20 @@ Whether the parachute has been deployed.
 
 **Parameters**
 
--   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute see [Long.js]<https://www.npmjs.com/package/long>
+-   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## parachuteGetArmed
+
+**Extends SpaceCenter**
+
+Whether the parachute has been armed or deployed. Only applicable to
+RealChutes parachutes.
+
+**Parameters**
+
+-   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5247,7 +7243,7 @@ The current state of the parachute.
 
 **Parameters**
 
--   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute see [Long.js]<https://www.npmjs.com/package/long>
+-   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5256,10 +7252,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The altitude at which the parachute will full deploy, in meters.
+Only applicable to stock parachutes.
 
 **Parameters**
 
--   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute see [Long.js]<https://www.npmjs.com/package/long>
+-   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5268,10 +7265,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The altitude at which the parachute will full deploy, in meters.
+Only applicable to stock parachutes.
 
 **Parameters**
 
--   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute see [Long.js]<https://www.npmjs.com/package/long>
+-   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -5281,10 +7279,11 @@ Returns **void**
 **Extends SpaceCenter**
 
 The minimum pressure at which the parachute will semi-deploy, in atmospheres.
+Only applicable to stock parachutes.
 
 **Parameters**
 
--   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute see [Long.js]<https://www.npmjs.com/package/long>
+-   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5293,10 +7292,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The minimum pressure at which the parachute will semi-deploy, in atmospheres.
+Only applicable to stock parachutes.
 
 **Parameters**
 
--   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute see [Long.js]<https://www.npmjs.com/package/long>
+-   `parachute` **Long** A long value representing the id for the SpaceCenter.Parachute
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -5306,16 +7306,17 @@ Returns **void**
 **Extends SpaceCenter**
 
 The position of the part in the given reference frame.
-This is a fixed position in the part, defined by the parts model.
+Returns: The position as a vector.
+<param name="referenceFrame">The reference frame that the returned
+position vector is in.</param>
+ This is a fixed position in the part, defined by the parts model.
 It s not necessarily the same as the parts center of mass.
 Use [M:SpaceCenter.Part.CenterOfMass](M:SpaceCenter.Part.CenterOfMass) to get the parts center of mass.
- <param name="referenceFrame">
- </param>
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5325,13 +7326,34 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 The position of the parts center of mass in the given reference frame.
 If the part is physicsless, this is equivalent to [M:SpaceCenter.Part.Position](M:SpaceCenter.Part.Position).
- <param name="referenceFrame">
- </param>
+Returns: The position as a vector.
+<param name="referenceFrame">The reference frame that the returned
+position vector is in.</param>
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## partBoundingBox
+
+**Extends SpaceCenter**
+
+The axis-aligned bounding box of the part in the given reference frame.
+Returns: The positions of the minimum and maximum vertices of the box,
+as position vectors.
+<param name="referenceFrame">The reference frame that the returned
+position vectors are in.</param>
+ This is computed from the collision mesh of the part.
+If the part is not collidable, the box has zero volume and is centered on
+the [M:SpaceCenter.Part.Position](M:SpaceCenter.Part.Position) of the part.
+
+**Parameters**
+
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5339,14 +7361,15 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The direction of the part in the given reference frame.
- <param name="referenceFrame">
- </param>
+The direction the part points in, in the given reference frame.
+Returns: The direction as a unit vector.
+<param name="referenceFrame">The reference frame that the returned
+direction is in.</param>
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5354,14 +7377,16 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The velocity of the part in the given reference frame.
- <param name="referenceFrame">
- </param>
+The linear velocity of the part in the given reference frame.
+Returns: The velocity as a vector. The vector points in the direction of travel,
+and its magnitude is the speed of the body in meters per second.
+<param name="referenceFrame">The reference frame that the returned
+velocity vector is in.</param>
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5369,14 +7394,15 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The rotation of the part in the given reference frame.
- <param name="referenceFrame">
- </param>
+The rotation of the part, in the given reference frame.
+Returns: The rotation as a quaternion of the form <math>(x, y, z, w)</math>.
+<param name="referenceFrame">The reference frame that the returned
+rotation is in.</param>
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5385,14 +7411,20 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Exert a constant force on the part, acting at the given position.
-Returns an object that can be used to remove or modify the force.
+Returns: An object that can be used to remove or modify the force.
+<param name="force">A vector pointing in the direction that the force acts,
+with its magnitude equal to the strength of the force in Newtons.</param>
+
+<param name="referenceFrame">The reference frame that the
+force and position are in.</param>
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
--   `force` **{number, number, number}** 
--   `position` **{number, number, number}** 
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
+-   `force` **{number, number, number}** A vector pointing in the direction that the force acts,
+    with its magnitude equal to the strength of the force in Newtons.
+-   `position` **{number, number, number}** The position at which the force acts, as a vector.
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5401,14 +7433,20 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Exert an instantaneous force on the part, acting at the given position.
-The force is applied instantaneously in a single physics update.
+<param name="force">A vector pointing in the direction that the force acts,
+with its magnitude equal to the strength of the force in Newtons.</param>
+
+<param name="referenceFrame">The reference frame that the
+force and position are in.</param>
+<remarks>The force is applied instantaneously in a single physics update.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
--   `force` **{number, number, number}** 
--   `position` **{number, number, number}** 
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
+-   `force` **{number, number, number}** A vector pointing in the direction that the force acts,
+    with its magnitude equal to the strength of the force in Newtons.
+-   `position` **{number, number, number}** The position at which the force acts, as a vector.
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **void** 
 
@@ -5417,12 +7455,12 @@ Returns **void**
 **Extends SpaceCenter**
 
 Internal name of the part, as used in
-<a href="http://wiki.kerbalspaceprogram.com/wiki/CFG_File_Documentation">part cfg files</a>.
+<a href="https://wiki.kerbalspaceprogram.com/wiki/CFG_File_Documentation">part cfg files</a>.
 For example "Mark1-2Pod".
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5434,7 +7472,7 @@ Title of the part, as shown when the part is right clicked in-game. For example 
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5442,13 +7480,16 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The name tag for the part. Can be set to a custom string using the in-game user interface.
-This requires either the <a href="http://github.com/krpc/NameTag/releases/latest">NameTag</a> or
-<a href="http://forum.kerbalspaceprogram.com/index.php?/topic/61827-/">kOS</a> mods to be installed.
+The name tag for the part. Can be set to a custom string using the
+in-game user interface.
+ This requires either the
+<a href="https://github.com/krpc/NameTag/releases/latest">NameTag</a> or
+<a href="https://forum.kerbalspaceprogram.com/index.php?/topic/61827-/">kOS</a>
+mod to be installed.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5456,14 +7497,67 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The name tag for the part. Can be set to a custom string using the in-game user interface.
-This requires either the <a href="http://github.com/krpc/NameTag/releases/latest">NameTag</a> or
-<a href="http://forum.kerbalspaceprogram.com/index.php?/topic/61827-/">kOS</a> mods to be installed.
+The name tag for the part. Can be set to a custom string using the
+in-game user interface.
+ This requires either the
+<a href="https://github.com/krpc/NameTag/releases/latest">NameTag</a> or
+<a href="https://forum.kerbalspaceprogram.com/index.php?/topic/61827-/">kOS</a>
+mod to be installed.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+Returns **void** 
+
+## partGetHighlighted
+
+**Extends SpaceCenter**
+
+Whether the part is highlighted.
+
+**Parameters**
+
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## partSetHighlighted
+
+**Extends SpaceCenter**
+
+Whether the part is highlighted.
+
+**Parameters**
+
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## partGetHighlightColor
+
+**Extends SpaceCenter**
+
+The color used to highlight the part, as an RGB triple.
+
+**Parameters**
+
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## partSetHighlightColor
+
+**Extends SpaceCenter**
+
+The color used to highlight the part, as an RGB triple.
+
+**Parameters**
+
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
+-   `value` **{number, number, number}** 
 
 Returns **void** 
 
@@ -5475,7 +7569,7 @@ The cost of the part, in units of funds.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5487,7 +7581,7 @@ The vessel that contains this part.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5495,12 +7589,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The parts parent. Returns <c>null</c> if the part does not have a parent.
-This, in combination with [M:SpaceCenter.Part.Children](M:SpaceCenter.Part.Children), can be used to traverse the vessels parts tree.
+The parts parent. Returns null if the part does not have a parent.
+This, in combination with [M:SpaceCenter.Part.Children](M:SpaceCenter.Part.Children), can be used to traverse the vessels
+parts tree.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5509,11 +7604,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The parts children. Returns an empty list if the part has no children.
-This, in combination with [M:SpaceCenter.Part.Parent](M:SpaceCenter.Part.Parent), can be used to traverse the vessels parts tree.
+This, in combination with [M:SpaceCenter.Part.Parent](M:SpaceCenter.Part.Parent), can be used to traverse the vessels
+parts tree.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5522,11 +7618,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Whether the part is axially attached to its parent, i.e. on the top
-or bottom of its parent. If the part has no parent, returns <c>false</c>.
+or bottom of its parent. If the part has no parent, returns false.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5535,11 +7631,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Whether the part is radially attached to its parent, i.e. on the side of its parent.
-If the part has no parent, returns <c>false</c>.
+If the part has no parent, returns false.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5547,11 +7643,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The stage in which this part will be activated. Returns -1 if the part is not activated by staging.
+The stage in which this part will be activated. Returns -1 if the part is not
+activated by staging.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5559,11 +7656,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The stage in which this part will be decoupled. Returns -1 if the part is never decoupled from the vessel.
+The stage in which this part will be decoupled. Returns -1 if the part is never
+decoupled from the vessel.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5571,11 +7669,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Whether the part is <a href="http://wiki.kerbalspaceprogram.com/wiki/Massless_part">massless</a>.
+Whether the part is
+<a href="https://wiki.kerbalspaceprogram.com/wiki/Massless_part">massless</a>.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5588,7 +7687,7 @@ Returns zero if the part is massless.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5596,11 +7695,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The mass of the part, not including any resources it contains, in kilograms. Returns zero if the part is massless.
+The mass of the part, not including any resources it contains, in kilograms.
+Returns zero if the part is massless.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5612,7 +7712,7 @@ Whether the part is shielded from the exterior of the vessel, for example by a f
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5624,7 +7724,7 @@ The dynamic pressure acting on the part, in Pascals.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5636,7 +7736,7 @@ The impact tolerance of the part, in meters per second.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5648,7 +7748,7 @@ Temperature of the part, in Kelvin.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5660,7 +7760,7 @@ Temperature of the skin of the part, in Kelvin.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5672,7 +7772,7 @@ Maximum temperature that the part can survive, in Kelvin.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5684,7 +7784,7 @@ Maximum temperature that the skin of the part can survive, in Kelvin.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5692,11 +7792,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A measure of how much energy it takes to increase the internal temperature of the part, in Joules per Kelvin.
+A measure of how much energy it takes to increase the internal temperature of the part,
+in Joules per Kelvin.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5704,11 +7805,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A measure of how much energy it takes to increase the skin temperature of the part, in Joules per Kelvin.
+A measure of how much energy it takes to increase the skin temperature of the part,
+in Joules per Kelvin.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5716,11 +7818,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A measure of how much energy it takes to increase the temperature of the resources contained in the part, in Joules per Kelvin.
+A measure of how much energy it takes to increase the temperature of the resources
+contained in the part, in Joules per Kelvin.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5731,11 +7834,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 The rate at which heat energy is begin generated by the part.
 For example, some engines generate heat by combusting fuel.
 Measured in energy per unit time, or power, in Watts.
-A positive value means the part is gaining heat energy, and negative means it is losing heat energy.
+A positive value means the part is gaining heat energy, and negative means it is losing
+heat energy.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5743,13 +7847,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The rate at which heat energy is conducting into or out of the part via contact with other parts.
-Measured in energy per unit time, or power, in Watts.
-A positive value means the part is gaining heat energy, and negative means it is losing heat energy.
+The rate at which heat energy is conducting into or out of the part via contact with
+other parts. Measured in energy per unit time, or power, in Watts.
+A positive value means the part is gaining heat energy, and negative means it is
+losing heat energy.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5757,13 +7862,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The rate at which heat energy is convecting into or out of the part from the surrounding atmosphere.
-Measured in energy per unit time, or power, in Watts.
-A positive value means the part is gaining heat energy, and negative means it is losing heat energy.
+The rate at which heat energy is convecting into or out of the part from the
+surrounding atmosphere. Measured in energy per unit time, or power, in Watts.
+A positive value means the part is gaining heat energy, and negative means it is
+losing heat energy.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5771,13 +7877,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The rate at which heat energy is radiating into or out of the part from the surrounding environment.
-Measured in energy per unit time, or power, in Watts.
-A positive value means the part is gaining heat energy, and negative means it is losing heat energy.
+The rate at which heat energy is radiating into or out of the part from the surrounding
+environment. Measured in energy per unit time, or power, in Watts.
+A positive value means the part is gaining heat energy, and negative means it is
+losing heat energy.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5792,7 +7899,7 @@ and negative means its skin is gaining heat energy.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5804,7 +7911,7 @@ A [T:SpaceCenter.Resources](T:SpaceCenter.Resources) object for the part.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5816,7 +7923,7 @@ Whether this part is crossfeed capable.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5828,7 +7935,7 @@ Whether this part is a fuel line.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5836,11 +7943,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The parts that are connected to this part via fuel lines, where the direction of the fuel line is into this part.
+The parts that are connected to this part via fuel lines, where the direction of the
+fuel line is into this part.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5848,11 +7956,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The parts that are connected to this part via fuel lines, where the direction of the fuel line is out of this part.
+The parts that are connected to this part via fuel lines, where the direction of the
+fuel line is out of this part.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5864,7 +7973,19 @@ The modules for this part.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## partGetAntenna
+
+**Extends SpaceCenter**
+
+A [T:SpaceCenter.Antenna](T:SpaceCenter.Antenna) if the part is an antenna, otherwise null.
+
+**Parameters**
+
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5872,11 +7993,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A [T:SpaceCenter.CargoBay](T:SpaceCenter.CargoBay) if the part is a cargo bay, otherwise <c>null</c>.
+A [T:SpaceCenter.CargoBay](T:SpaceCenter.CargoBay) if the part is a cargo bay, otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5884,11 +8005,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A [T:SpaceCenter.ControlSurface](T:SpaceCenter.ControlSurface) if the part is an aerodynamic control surface, otherwise <c>null</c>.
+A [T:SpaceCenter.ControlSurface](T:SpaceCenter.ControlSurface) if the part is an aerodynamic control surface,
+otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5896,11 +8018,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A [T:SpaceCenter.Decoupler](T:SpaceCenter.Decoupler) if the part is a decoupler, otherwise <c>null</c>.
+A [T:SpaceCenter.Decoupler](T:SpaceCenter.Decoupler) if the part is a decoupler, otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5908,11 +8030,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A [T:SpaceCenter.DockingPort](T:SpaceCenter.DockingPort) if the part is a docking port, otherwise <c>null</c>.
+A [T:SpaceCenter.DockingPort](T:SpaceCenter.DockingPort) if the part is a docking port, otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5920,11 +8042,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-An [T:SpaceCenter.Engine](T:SpaceCenter.Engine) if the part is an engine, otherwise <c>null</c>.
+An [T:SpaceCenter.Engine](T:SpaceCenter.Engine) if the part is an engine, otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5932,11 +8054,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-An [T:SpaceCenter.Experiment](T:SpaceCenter.Experiment) if the part is a science experiment, otherwise <c>null</c>.
+An [T:SpaceCenter.Experiment](T:SpaceCenter.Experiment) if the part is a science experiment, otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5944,11 +8066,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A [T:SpaceCenter.Fairing](T:SpaceCenter.Fairing) if the part is a fairing, otherwise <c>null</c>.
+A [T:SpaceCenter.Fairing](T:SpaceCenter.Fairing) if the part is a fairing, otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5956,38 +8078,26 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-An [T:SpaceCenter.Intake](T:SpaceCenter.Intake) if the part is an intake, otherwise <c>null</c>.
-This includes any part that generates thrust. This covers many different types of engine,
-including liquid fuel rockets, solid rocket boosters and jet engines.
+An [T:SpaceCenter.Intake](T:SpaceCenter.Intake) if the part is an intake, otherwise null.
+ This includes any part that generates thrust. This covers many different types
+of engine, including liquid fuel rockets, solid rocket boosters and jet engines.
 For RCS thrusters see [T:SpaceCenter.RCS](T:SpaceCenter.RCS).
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
-## partGetLandingGear
+## partGetLeg
 
 **Extends SpaceCenter**
 
-A [T:SpaceCenter.LandingGear](T:SpaceCenter.LandingGear) if the part is a landing gear, otherwise <c>null</c>.
+A [T:SpaceCenter.Leg](T:SpaceCenter.Leg) if the part is a landing leg, otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
-
-Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
-
-## partGetLandingLeg
-
-**Extends SpaceCenter**
-
-A [T:SpaceCenter.LandingLeg](T:SpaceCenter.LandingLeg) if the part is a landing leg, otherwise <c>null</c>.
-
-**Parameters**
-
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -5995,11 +8105,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A [T:SpaceCenter.LaunchClamp](T:SpaceCenter.LaunchClamp) if the part is a launch clamp, otherwise <c>null</c>.
+A [T:SpaceCenter.LaunchClamp](T:SpaceCenter.LaunchClamp) if the part is a launch clamp, otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6007,11 +8117,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A [T:SpaceCenter.Light](T:SpaceCenter.Light) if the part is a light, otherwise <c>null</c>.
+A [T:SpaceCenter.Light](T:SpaceCenter.Light) if the part is a light, otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6019,11 +8129,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A [T:SpaceCenter.Parachute](T:SpaceCenter.Parachute) if the part is a parachute, otherwise <c>null</c>.
+A [T:SpaceCenter.Parachute](T:SpaceCenter.Parachute) if the part is a parachute, otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6031,11 +8141,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A [T:SpaceCenter.Radiator](T:SpaceCenter.Radiator) if the part is a radiator, otherwise <c>null</c>.
+A [T:SpaceCenter.Radiator](T:SpaceCenter.Radiator) if the part is a radiator, otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6043,11 +8153,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A [T:SpaceCenter.RCS](T:SpaceCenter.RCS) if the part is an RCS block/thruster, otherwise <c>null</c>.
+A [T:SpaceCenter.RCS](T:SpaceCenter.RCS) if the part is an RCS block/thruster, otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6055,11 +8165,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A [T:SpaceCenter.ReactionWheel](T:SpaceCenter.ReactionWheel) if the part is a reaction wheel, otherwise <c>null</c>.
+A [T:SpaceCenter.ReactionWheel](T:SpaceCenter.ReactionWheel) if the part is a reaction wheel, otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6067,11 +8177,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A [T:SpaceCenter.ResourceConverter](T:SpaceCenter.ResourceConverter) if the part is a resource converter, otherwise <c>null</c>.
+A [T:SpaceCenter.ResourceConverter](T:SpaceCenter.ResourceConverter) if the part is a resource converter,
+otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6079,11 +8190,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A [T:SpaceCenter.ResourceHarvester](T:SpaceCenter.ResourceHarvester) if the part is a resource harvester, otherwise <c>null</c>.
+A [T:SpaceCenter.ResourceHarvester](T:SpaceCenter.ResourceHarvester) if the part is a resource harvester,
+otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6091,11 +8203,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A [T:SpaceCenter.Sensor](T:SpaceCenter.Sensor) if the part is a sensor, otherwise <c>null</c>.
+A [T:SpaceCenter.Sensor](T:SpaceCenter.Sensor) if the part is a sensor, otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6103,11 +8215,23 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A [T:SpaceCenter.SolarPanel](T:SpaceCenter.SolarPanel) if the part is a solar panel, otherwise <c>null</c>.
+A [T:SpaceCenter.SolarPanel](T:SpaceCenter.SolarPanel) if the part is a solar panel, otherwise null.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## partGetWheel
+
+**Extends SpaceCenter**
+
+A [T:SpaceCenter.Wheel](T:SpaceCenter.Wheel) if the part is a wheel, otherwise null.
+
+**Parameters**
+
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6120,7 +8244,7 @@ in the parts reference frame ([T:SpaceCenter.ReferenceFrame](T:SpaceCenter.Refer
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6128,12 +8252,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The inertia tensor of the part in the parts reference frame ([T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame)).
+The inertia tensor of the part in the parts reference frame
+([T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame)).
 Returns the 3x3 matrix as a list of elements, in row-major order.
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6141,13 +8266,18 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The reference frame that is fixed relative to this part, and centered on a fixed position within the part, defined by the parts model.
-<list type="bullet"><item><description>The origin is at the position of the part, as returned by [M:SpaceCenter.Part.Position](M:SpaceCenter.Part.Position).</description></item><item><description>The axes rotate with the part.</description></item><item><description>The x, y and z axis directions depend on the design of the part.</description></item></list> For docking port parts, this reference frame is not necessarily equivalent to the reference frame
-for the docking port, returned by [M:SpaceCenter.DockingPort.ReferenceFrame](M:SpaceCenter.DockingPort.ReferenceFrame).
+The reference frame that is fixed relative to this part, and centered on a fixed
+position within the part, defined by the parts model.
+<list type="bullet"><item><description>The origin is at the position of the part, as returned by
+[M:SpaceCenter.Part.Position](M:SpaceCenter.Part.Position).</description></item><item><description>The axes rotate with the part.</description></item><item><description>The x, y and z axis directions depend on the design of the part.
+</description></item></list><remarks>
+For docking port parts, this reference frame is not necessarily equivalent to the
+reference frame for the docking port, returned by
+[M:SpaceCenter.DockingPort.ReferenceFrame](M:SpaceCenter.DockingPort.ReferenceFrame).
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6155,13 +8285,18 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The reference frame that is fixed relative to this part, and centered on its center of mass.
-<list type="bullet"><item><description>The origin is at the center of mass of the part, as returned by [M:SpaceCenter.Part.CenterOfMass](M:SpaceCenter.Part.CenterOfMass).</description></item><item><description>The axes rotate with the part.</description></item><item><description>The x, y and z axis directions depend on the design of the part.</description></item></list> For docking port parts, this reference frame is not necessarily equivalent to the reference frame
-for the docking port, returned by [M:SpaceCenter.DockingPort.ReferenceFrame](M:SpaceCenter.DockingPort.ReferenceFrame).
+The reference frame that is fixed relative to this part, and centered on its
+center of mass.
+<list type="bullet"><item><description>The origin is at the center of mass of the part, as returned by
+[M:SpaceCenter.Part.CenterOfMass](M:SpaceCenter.Part.CenterOfMass).</description></item><item><description>The axes rotate with the part.</description></item><item><description>The x, y and z axis directions depend on the design of the part.
+</description></item></list><remarks>
+For docking port parts, this reference frame is not necessarily equivalent to the
+reference frame for the docking port, returned by
+[M:SpaceCenter.DockingPort.ReferenceFrame](M:SpaceCenter.DockingPort.ReferenceFrame).
 
 **Parameters**
 
--   `part` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `part` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6169,14 +8304,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A list of parts whose [M:SpaceCenter.Part.Name](M:SpaceCenter.Part.Name) is &lt;paramref name="name}.
- <param name="name">
- </param>
+A list of parts whose [M:SpaceCenter.Part.Name](M:SpaceCenter.Part.Name) is {name}.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
--   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** \-
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
+-   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6184,14 +8317,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A list of all parts whose [M:SpaceCenter.Part.Title](M:SpaceCenter.Part.Title) is &lt;paramref name="title}.
- <param name="title">
- </param>
+A list of all parts whose [M:SpaceCenter.Part.Title](M:SpaceCenter.Part.Title) is {title}.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
--   `title` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** \-
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
+-   `title` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6199,14 +8330,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A list of all parts whose [M:SpaceCenter.Part.Tag](M:SpaceCenter.Part.Tag) is &lt;paramref name="tag}.
- <param name="tag">
- </param>
+A list of all parts whose [M:SpaceCenter.Part.Tag](M:SpaceCenter.Part.Tag) is {tag}.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
--   `tag` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** \-
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
+-   `tag` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6215,14 +8344,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 A list of all parts that contain a [T:SpaceCenter.Module](T:SpaceCenter.Module) whose
-[M:SpaceCenter.Module.Name](M:SpaceCenter.Module.Name) is &lt;paramref name="moduleName}.
- <param name="moduleName">
- </param>
+[M:SpaceCenter.Module.Name](M:SpaceCenter.Module.Name) is {moduleName}.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
--   `moduleName` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** \-
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
+-   `moduleName` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6230,14 +8357,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A list of all parts that are activated in the given &lt;paramref name="stage}.
- <param name="stage">
- </param>
+A list of all parts that are activated in the given {stage}.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
--   `stage` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** \-
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
+-   `stage` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6245,14 +8370,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-A list of all parts that are decoupled in the given &lt;paramref name="stage}.
- <param name="stage">
- </param>
+A list of all parts that are decoupled in the given {stage}.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
--   `stage` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** \-
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
+-   `stage` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6261,14 +8384,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 A list of modules (combined across all parts in the vessel) whose
-[M:SpaceCenter.Module.Name](M:SpaceCenter.Module.Name) is &lt;paramref name="moduleName}.
- <param name="moduleName">
- </param>
+[M:SpaceCenter.Module.Name](M:SpaceCenter.Module.Name) is {moduleName}.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
--   `moduleName` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** \-
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
+-   `moduleName` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6280,7 +8401,7 @@ A list of all of the vessels parts.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6292,7 +8413,7 @@ The vessels root part.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6304,7 +8425,7 @@ The part from which the vessel is controlled.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6316,10 +8437,22 @@ The part from which the vessel is controlled.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
+-   `value` **Long** A long value representing the id for the SpaceCenter.Part
 
 Returns **void** 
+
+## partsGetAntennas
+
+**Extends SpaceCenter**
+
+A list of all antennas in the vessel.
+
+**Parameters**
+
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
 ## partsGetControlSurfaces
 
@@ -6329,7 +8462,7 @@ A list of all control surfaces in the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6341,7 +8474,7 @@ A list of all cargo bays in the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6353,7 +8486,7 @@ A list of all decouplers in the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6365,7 +8498,7 @@ A list of all docking ports in the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6374,12 +8507,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 A list of all engines in the vessel.
-This includes any part that generates thrust. This covers many different types of engine,
-including liquid fuel rockets, solid rocket boosters, jet engines and RCS thrusters.
+ This includes any part that generates thrust. This covers many different types
+of engine, including liquid fuel rockets, solid rocket boosters, jet engines and
+RCS thrusters.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6391,7 +8525,7 @@ A list of all science experiments in the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6403,7 +8537,7 @@ A list of all fairings in the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6415,23 +8549,11 @@ A list of all intakes in the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
-## partsGetLandingGear
-
-**Extends SpaceCenter**
-
-A list of all landing gear attached to the vessel.
-
-**Parameters**
-
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
-
-Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
-
-## partsGetLandingLegs
+## partsGetLegs
 
 **Extends SpaceCenter**
 
@@ -6439,7 +8561,7 @@ A list of all landing legs attached to the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6451,7 +8573,7 @@ A list of all launch clamps attached to the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6463,7 +8585,7 @@ A list of all lights in the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6475,7 +8597,7 @@ A list of all parachutes in the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6487,7 +8609,7 @@ A list of all radiators in the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6499,7 +8621,7 @@ A list of all RCS blocks/thrusters in the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6511,7 +8633,7 @@ A list of all reaction wheels in the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6523,7 +8645,7 @@ A list of all resource converters in the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6535,7 +8657,7 @@ A list of all resource harvesters in the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6547,7 +8669,7 @@ A list of all sensors in the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6559,7 +8681,19 @@ A list of all solar panels in the vessel.
 
 **Parameters**
 
--   `parts` **Long** A long value representing the id for the SpaceCenter.Parts see [Long.js]<https://www.npmjs.com/package/long>
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## partsGetWheels
+
+**Extends SpaceCenter**
+
+A list of all wheels in the vessel.
+
+**Parameters**
+
+-   `parts` **Long** A long value representing the id for the SpaceCenter.Parts
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6571,7 +8705,7 @@ The name of the propellant.
 
 **Parameters**
 
--   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant see [Long.js]<https://www.npmjs.com/package/long>
+-   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6583,7 +8717,7 @@ The current amount of propellant.
 
 **Parameters**
 
--   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant see [Long.js]<https://www.npmjs.com/package/long>
+-   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6595,7 +8729,7 @@ The required amount of propellant.
 
 **Parameters**
 
--   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant see [Long.js]<https://www.npmjs.com/package/long>
+-   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6603,11 +8737,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The total amount of the underlying resource currently reachable given resource flow rules.
+The total amount of the underlying resource currently reachable given
+resource flow rules.
 
 **Parameters**
 
--   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant see [Long.js]<https://www.npmjs.com/package/long>
+-   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6615,11 +8750,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The total vehicle capacity for the underlying propellant resource, restricted by resource flow rules.
+The total vehicle capacity for the underlying propellant resource,
+restricted by resource flow rules.
 
 **Parameters**
 
--   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant see [Long.js]<https://www.npmjs.com/package/long>
+-   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6627,11 +8763,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-If this propellant should be ignored when calculating required mass flow given specific impulse.
+If this propellant should be ignored when calculating required mass flow
+given specific impulse.
 
 **Parameters**
 
--   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant see [Long.js]<https://www.npmjs.com/package/long>
+-   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6643,7 +8780,7 @@ If this propellant should be ignored for thrust curve calculations.
 
 **Parameters**
 
--   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant see [Long.js]<https://www.npmjs.com/package/long>
+-   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6655,7 +8792,7 @@ If this propellant has a stack gauge or not.
 
 **Parameters**
 
--   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant see [Long.js]<https://www.npmjs.com/package/long>
+-   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6667,7 +8804,7 @@ If this propellant is deprived.
 
 **Parameters**
 
--   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant see [Long.js]<https://www.npmjs.com/package/long>
+-   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6679,19 +8816,7 @@ The propellant ratio.
 
 **Parameters**
 
--   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant see [Long.js]<https://www.npmjs.com/package/long>
-
-Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
-
-## propellantGetConnectedResources
-
-**Extends SpaceCenter**
-
-The reachable resources connected to this propellant.
-
-**Parameters**
-
--   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant see [Long.js]<https://www.npmjs.com/package/long>
+-   `propellant` **Long** A long value representing the id for the SpaceCenter.Propellant
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6703,7 +8828,7 @@ The part object for this RCS.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6712,13 +8837,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Whether the RCS thrusters are active.
-An RCS thruster is inactive if the RCS action group is disabled ([M:SpaceCenter.Control.RCS](M:SpaceCenter.Control.RCS)),
-the RCS thruster itself is not enabled ([M:SpaceCenter.RCS.Enabled](M:SpaceCenter.RCS.Enabled)) or
-it is covered by a fairing ([M:SpaceCenter.Part.Shielded](M:SpaceCenter.Part.Shielded)).
+An RCS thruster is inactive if the RCS action group is disabled
+([M:SpaceCenter.Control.RCS](M:SpaceCenter.Control.RCS)), the RCS thruster itself is not enabled
+([M:SpaceCenter.RCS.Enabled](M:SpaceCenter.RCS.Enabled)) or it is covered by a fairing ([M:SpaceCenter.Part.Shielded](M:SpaceCenter.Part.Shielded)).
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6730,7 +8855,7 @@ Whether the RCS thrusters are enabled.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6742,7 +8867,7 @@ Whether the RCS thrusters are enabled.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -6755,7 +8880,7 @@ Whether the RCS thruster will fire when pitch control input is given.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6767,7 +8892,7 @@ Whether the RCS thruster will fire when pitch control input is given.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -6780,7 +8905,7 @@ Whether the RCS thruster will fire when yaw control input is given.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6792,7 +8917,7 @@ Whether the RCS thruster will fire when yaw control input is given.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -6805,7 +8930,7 @@ Whether the RCS thruster will fire when roll control input is given.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6817,7 +8942,7 @@ Whether the RCS thruster will fire when roll control input is given.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -6830,7 +8955,7 @@ Whether the RCS thruster will fire when pitch control input is given.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6842,7 +8967,7 @@ Whether the RCS thruster will fire when pitch control input is given.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -6855,7 +8980,7 @@ Whether the RCS thruster will fire when yaw control input is given.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6867,7 +8992,7 @@ Whether the RCS thruster will fire when yaw control input is given.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -6880,7 +9005,7 @@ Whether the RCS thruster will fire when roll control input is given.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6892,7 +9017,7 @@ Whether the RCS thruster will fire when roll control input is given.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -6901,13 +9026,14 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-The available torque in the pitch, roll and yaw axes of the vessel, in Newton meters.
-These axes correspond to the coordinate axes of the [M:SpaceCenter.Vessel.ReferenceFrame](M:SpaceCenter.Vessel.ReferenceFrame).
-Returns zero if the RCS is inactive.
+The available torque, in Newton meters, that can be produced by this RCS,
+in the positive and negative pitch, roll and yaw axes of the vessel. These axes
+correspond to the coordinate axes of the [M:SpaceCenter.Vessel.ReferenceFrame](M:SpaceCenter.Vessel.ReferenceFrame).
+Returns zero if RCS is disable.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6915,11 +9041,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The maximum amount of thrust that can be produced by the RCS thrusters when active, in Newtons.
+The maximum amount of thrust that can be produced by the RCS thrusters when active,
+in Newtons.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6927,11 +9054,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The maximum amount of thrust that can be produced by the RCS thrusters when active in a vacuum, in Newtons.
+The maximum amount of thrust that can be produced by the RCS thrusters when active
+in a vacuum, in Newtons.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6943,7 +9071,7 @@ A list of thrusters, one of each nozzel in the RCS part.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6956,7 +9084,7 @@ if the RCS is not active.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6968,7 +9096,7 @@ The vacuum specific impulse of the RCS, in seconds.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6980,7 +9108,7 @@ The specific impulse of the RCS at sea level on Kerbin, in seconds.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -6992,7 +9120,7 @@ The names of resources that the RCS consumes.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7005,7 +9133,7 @@ to the ratios at which they are consumed by the RCS.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7014,11 +9142,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Whether the RCS has fuel available.
-The RCS thruster must be activated for this property to update correctly.
+ The RCS thruster must be activated for this property to update correctly.
 
 **Parameters**
 
--   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS see [Long.js]<https://www.npmjs.com/package/long>
+-   `rcs` **Long** A long value representing the id for the SpaceCenter.RCS
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7030,7 +9158,7 @@ The part object for this radiator.
 
 **Parameters**
 
--   `radiator` **Long** A long value representing the id for the SpaceCenter.Radiator see [Long.js]<https://www.npmjs.com/package/long>
+-   `radiator` **Long** A long value representing the id for the SpaceCenter.Radiator
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7042,7 +9170,7 @@ Whether the radiator is deployable.
 
 **Parameters**
 
--   `radiator` **Long** A long value representing the id for the SpaceCenter.Radiator see [Long.js]<https://www.npmjs.com/package/long>
+-   `radiator` **Long** A long value representing the id for the SpaceCenter.Radiator
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7050,12 +9178,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-For a deployable radiator, <c>true</c> if the radiator is extended.
-If the radiator is not deployable, this is always <c>true</c>.
+For a deployable radiator, true if the radiator is extended.
+If the radiator is not deployable, this is always true.
 
 **Parameters**
 
--   `radiator` **Long** A long value representing the id for the SpaceCenter.Radiator see [Long.js]<https://www.npmjs.com/package/long>
+-   `radiator` **Long** A long value representing the id for the SpaceCenter.Radiator
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7063,12 +9191,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-For a deployable radiator, <c>true</c> if the radiator is extended.
-If the radiator is not deployable, this is always <c>true</c>.
+For a deployable radiator, true if the radiator is extended.
+If the radiator is not deployable, this is always true.
 
 **Parameters**
 
--   `radiator` **Long** A long value representing the id for the SpaceCenter.Radiator see [Long.js]<https://www.npmjs.com/package/long>
+-   `radiator` **Long** A long value representing the id for the SpaceCenter.Radiator
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -7078,11 +9206,11 @@ Returns **void**
 **Extends SpaceCenter**
 
 The current state of the radiator.
-A fixed radiator is always [M:SpaceCenter.RadiatorState.Extended](M:SpaceCenter.RadiatorState.Extended).
+ A fixed radiator is always [M:SpaceCenter.RadiatorState.Extended](M:SpaceCenter.RadiatorState.Extended).
 
 **Parameters**
 
--   `radiator` **Long** A long value representing the id for the SpaceCenter.Radiator see [Long.js]<https://www.npmjs.com/package/long>
+-   `radiator` **Long** A long value representing the id for the SpaceCenter.Radiator
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7094,7 +9222,7 @@ The part object for this reaction wheel.
 
 **Parameters**
 
--   `reactionWheel` **Long** A long value representing the id for the SpaceCenter.ReactionWheel see [Long.js]<https://www.npmjs.com/package/long>
+-   `reactionWheel` **Long** A long value representing the id for the SpaceCenter.ReactionWheel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7106,7 +9234,7 @@ Whether the reaction wheel is active.
 
 **Parameters**
 
--   `reactionWheel` **Long** A long value representing the id for the SpaceCenter.ReactionWheel see [Long.js]<https://www.npmjs.com/package/long>
+-   `reactionWheel` **Long** A long value representing the id for the SpaceCenter.ReactionWheel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7118,7 +9246,7 @@ Whether the reaction wheel is active.
 
 **Parameters**
 
--   `reactionWheel` **Long** A long value representing the id for the SpaceCenter.ReactionWheel see [Long.js]<https://www.npmjs.com/package/long>
+-   `reactionWheel` **Long** A long value representing the id for the SpaceCenter.ReactionWheel
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -7131,7 +9259,7 @@ Whether the reaction wheel is broken.
 
 **Parameters**
 
--   `reactionWheel` **Long** A long value representing the id for the SpaceCenter.ReactionWheel see [Long.js]<https://www.npmjs.com/package/long>
+-   `reactionWheel` **Long** A long value representing the id for the SpaceCenter.ReactionWheel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7139,13 +9267,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The available torque in the pitch, roll and yaw axes of the vessel, in Newton meters.
-These axes correspond to the coordinate axes of the [M:SpaceCenter.Vessel.ReferenceFrame](M:SpaceCenter.Vessel.ReferenceFrame).
+The available torque, in Newton meters, that can be produced by this reaction wheel,
+in the positive and negative pitch, roll and yaw axes of the vessel. These axes
+correspond to the coordinate axes of the [M:SpaceCenter.Vessel.ReferenceFrame](M:SpaceCenter.Vessel.ReferenceFrame).
 Returns zero if the reaction wheel is inactive or broken.
 
 **Parameters**
 
--   `reactionWheel` **Long** A long value representing the id for the SpaceCenter.ReactionWheel see [Long.js]<https://www.npmjs.com/package/long>
+-   `reactionWheel` **Long** A long value representing the id for the SpaceCenter.ReactionWheel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7153,13 +9282,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The maximum torque the reaction wheel can provide, is it active,
-in the pitch, roll and yaw axes of the vessel, in Newton meters.
+The maximum torque, in Newton meters, that can be produced by this reaction wheel,
+when it is active, in the positive and negative pitch, roll and yaw axes of the vessel.
 These axes correspond to the coordinate axes of the [M:SpaceCenter.Vessel.ReferenceFrame](M:SpaceCenter.Vessel.ReferenceFrame).
 
 **Parameters**
 
--   `reactionWheel` **Long** A long value representing the id for the SpaceCenter.ReactionWheel see [Long.js]<https://www.npmjs.com/package/long>
+-   `reactionWheel` **Long** A long value representing the id for the SpaceCenter.ReactionWheel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7171,7 +9300,7 @@ True if the specified converter is active.
 
 **Parameters**
 
--   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter
 -   `index` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Index of the converter.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -7184,7 +9313,7 @@ The name of the specified converter.
 
 **Parameters**
 
--   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter
 -   `index` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Index of the converter.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -7197,7 +9326,7 @@ Start the specified converter.
 
 **Parameters**
 
--   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter
 -   `index` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Index of the converter.
 
 Returns **void** 
@@ -7210,7 +9339,7 @@ Stop the specified converter.
 
 **Parameters**
 
--   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter
 -   `index` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Index of the converter.
 
 Returns **void** 
@@ -7223,7 +9352,7 @@ The state of the specified converter.
 
 **Parameters**
 
--   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter
 -   `index` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Index of the converter.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -7237,7 +9366,7 @@ This is the full status message shown in the in-game UI.
 
 **Parameters**
 
--   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter
 -   `index` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Index of the converter.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -7250,7 +9379,7 @@ List of the names of resources consumed by the specified converter.
 
 **Parameters**
 
--   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter
 -   `index` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Index of the converter.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -7263,7 +9392,7 @@ List of the names of resources produced by the specified converter.
 
 **Parameters**
 
--   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter
 -   `index` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Index of the converter.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -7276,7 +9405,7 @@ The part object for this converter.
 
 **Parameters**
 
--   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7288,7 +9417,43 @@ The number of converters in the part.
 
 **Parameters**
 
--   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## resourceConverterGetThermalEfficiency
+
+**Extends SpaceCenter**
+
+The thermal efficiency of the converter, as a percentage of its maximum.
+
+**Parameters**
+
+-   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## resourceConverterGetCoreTemperature
+
+**Extends SpaceCenter**
+
+The core temperature of the converter, in Kelvin.
+
+**Parameters**
+
+-   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## resourceConverterGetOptimumCoreTemperature
+
+**Extends SpaceCenter**
+
+The core temperature at which the converter will operate with peak efficiency, in Kelvin.
+
+**Parameters**
+
+-   `resourceConverter` **Long** A long value representing the id for the SpaceCenter.ResourceConverter
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7300,7 +9465,7 @@ The part object for this harvester.
 
 **Parameters**
 
--   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7312,7 +9477,7 @@ The state of the harvester.
 
 **Parameters**
 
--   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7324,7 +9489,7 @@ Whether the harvester is deployed.
 
 **Parameters**
 
--   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7336,7 +9501,7 @@ Whether the harvester is deployed.
 
 **Parameters**
 
--   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -7349,7 +9514,7 @@ Whether the harvester is actively drilling.
 
 **Parameters**
 
--   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7361,7 +9526,7 @@ Whether the harvester is actively drilling.
 
 **Parameters**
 
--   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -7374,7 +9539,7 @@ The rate at which the drill is extracting ore, in units per second.
 
 **Parameters**
 
--   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7386,7 +9551,7 @@ The thermal efficiency of the drill, as a percentage of its maximum.
 
 **Parameters**
 
--   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7398,7 +9563,7 @@ The core temperature of the drill, in Kelvin.
 
 **Parameters**
 
--   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7410,7 +9575,7 @@ The core temperature at which the drill will operate with peak efficiency, in Ke
 
 **Parameters**
 
--   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceHarvester` **Long** A long value representing the id for the SpaceCenter.ResourceHarvester
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7422,7 +9587,7 @@ Data amount.
 
 **Parameters**
 
--   `scienceData` **Long** A long value representing the id for the SpaceCenter.ScienceData see [Long.js]<https://www.npmjs.com/package/long>
+-   `scienceData` **Long** A long value representing the id for the SpaceCenter.ScienceData
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7434,7 +9599,7 @@ Science value.
 
 **Parameters**
 
--   `scienceData` **Long** A long value representing the id for the SpaceCenter.ScienceData see [Long.js]<https://www.npmjs.com/package/long>
+-   `scienceData` **Long** A long value representing the id for the SpaceCenter.ScienceData
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7446,7 +9611,7 @@ Transmit value.
 
 **Parameters**
 
--   `scienceData` **Long** A long value representing the id for the SpaceCenter.ScienceData see [Long.js]<https://www.npmjs.com/package/long>
+-   `scienceData` **Long** A long value representing the id for the SpaceCenter.ScienceData
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7454,11 +9619,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Amount of science already earned from this subject, not updated until after transmission/recovery.
+Amount of science already earned from this subject, not updated until after
+transmission/recovery.
 
 **Parameters**
 
--   `scienceSubject` **Long** A long value representing the id for the SpaceCenter.ScienceSubject see [Long.js]<https://www.npmjs.com/package/long>
+-   `scienceSubject` **Long** A long value representing the id for the SpaceCenter.ScienceSubject
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7470,7 +9636,7 @@ Total science allowable for this subject.
 
 **Parameters**
 
--   `scienceSubject` **Long** A long value representing the id for the SpaceCenter.ScienceSubject see [Long.js]<https://www.npmjs.com/package/long>
+-   `scienceSubject` **Long** A long value representing the id for the SpaceCenter.ScienceSubject
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7482,7 +9648,7 @@ Whether the experiment has been completed.
 
 **Parameters**
 
--   `scienceSubject` **Long** A long value representing the id for the SpaceCenter.ScienceSubject see [Long.js]<https://www.npmjs.com/package/long>
+-   `scienceSubject` **Long** A long value representing the id for the SpaceCenter.ScienceSubject
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7494,7 +9660,7 @@ Multiply science value by this to determine data amount in mits.
 
 **Parameters**
 
--   `scienceSubject` **Long** A long value representing the id for the SpaceCenter.ScienceSubject see [Long.js]<https://www.npmjs.com/package/long>
+-   `scienceSubject` **Long** A long value representing the id for the SpaceCenter.ScienceSubject
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7502,11 +9668,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Diminishing value multiplier for decreasing the science value returned from repeated experiments.
+Diminishing value multiplier for decreasing the science value returned from repeated
+experiments.
 
 **Parameters**
 
--   `scienceSubject` **Long** A long value representing the id for the SpaceCenter.ScienceSubject see [Long.js]<https://www.npmjs.com/package/long>
+-   `scienceSubject` **Long** A long value representing the id for the SpaceCenter.ScienceSubject
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7518,7 +9685,7 @@ Multiplier for specific Celestial Body/Experiment Situation combination.
 
 **Parameters**
 
--   `scienceSubject` **Long** A long value representing the id for the SpaceCenter.ScienceSubject see [Long.js]<https://www.npmjs.com/package/long>
+-   `scienceSubject` **Long** A long value representing the id for the SpaceCenter.ScienceSubject
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7530,7 +9697,7 @@ Title of science subject, displayed in science archives
 
 **Parameters**
 
--   `scienceSubject` **Long** A long value representing the id for the SpaceCenter.ScienceSubject see [Long.js]<https://www.npmjs.com/package/long>
+-   `scienceSubject` **Long** A long value representing the id for the SpaceCenter.ScienceSubject
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7542,7 +9709,7 @@ The part object for this sensor.
 
 **Parameters**
 
--   `sensor` **Long** A long value representing the id for the SpaceCenter.Sensor see [Long.js]<https://www.npmjs.com/package/long>
+-   `sensor` **Long** A long value representing the id for the SpaceCenter.Sensor
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7554,7 +9721,7 @@ Whether the sensor is active.
 
 **Parameters**
 
--   `sensor` **Long** A long value representing the id for the SpaceCenter.Sensor see [Long.js]<https://www.npmjs.com/package/long>
+-   `sensor` **Long** A long value representing the id for the SpaceCenter.Sensor
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7566,7 +9733,7 @@ Whether the sensor is active.
 
 **Parameters**
 
--   `sensor` **Long** A long value representing the id for the SpaceCenter.Sensor see [Long.js]<https://www.npmjs.com/package/long>
+-   `sensor` **Long** A long value representing the id for the SpaceCenter.Sensor
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -7579,19 +9746,7 @@ The current value of the sensor.
 
 **Parameters**
 
--   `sensor` **Long** A long value representing the id for the SpaceCenter.Sensor see [Long.js]<https://www.npmjs.com/package/long>
-
-Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
-
-## sensorGetPowerUsage
-
-**Extends SpaceCenter**
-
-The current power usage of the sensor, in units of charge per second.
-
-**Parameters**
-
--   `sensor` **Long** A long value representing the id for the SpaceCenter.Sensor see [Long.js]<https://www.npmjs.com/package/long>
+-   `sensor` **Long** A long value representing the id for the SpaceCenter.Sensor
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7603,7 +9758,19 @@ The part object for this solar panel.
 
 **Parameters**
 
--   `solarPanel` **Long** A long value representing the id for the SpaceCenter.SolarPanel see [Long.js]<https://www.npmjs.com/package/long>
+-   `solarPanel` **Long** A long value representing the id for the SpaceCenter.SolarPanel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## solarPanelGetDeployable
+
+**Extends SpaceCenter**
+
+Whether the solar panel is deployable.
+
+**Parameters**
+
+-   `solarPanel` **Long** A long value representing the id for the SpaceCenter.SolarPanel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7615,7 +9782,7 @@ Whether the solar panel is extended.
 
 **Parameters**
 
--   `solarPanel` **Long** A long value representing the id for the SpaceCenter.SolarPanel see [Long.js]<https://www.npmjs.com/package/long>
+-   `solarPanel` **Long** A long value representing the id for the SpaceCenter.SolarPanel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7627,7 +9794,7 @@ Whether the solar panel is extended.
 
 **Parameters**
 
--   `solarPanel` **Long** A long value representing the id for the SpaceCenter.SolarPanel see [Long.js]<https://www.npmjs.com/package/long>
+-   `solarPanel` **Long** A long value representing the id for the SpaceCenter.SolarPanel
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -7640,7 +9807,7 @@ The current state of the solar panel.
 
 **Parameters**
 
--   `solarPanel` **Long** A long value representing the id for the SpaceCenter.SolarPanel see [Long.js]<https://www.npmjs.com/package/long>
+-   `solarPanel` **Long** A long value representing the id for the SpaceCenter.SolarPanel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7653,7 +9820,7 @@ units of charge per second.
 
 **Parameters**
 
--   `solarPanel` **Long** A long value representing the id for the SpaceCenter.SolarPanel see [Long.js]<https://www.npmjs.com/package/long>
+-   `solarPanel` **Long** A long value representing the id for the SpaceCenter.SolarPanel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7666,7 +9833,7 @@ as a percentage. A value between 0 and 1.
 
 **Parameters**
 
--   `solarPanel` **Long** A long value representing the id for the SpaceCenter.SolarPanel see [Long.js]<https://www.npmjs.com/package/long>
+-   `solarPanel` **Long** A long value representing the id for the SpaceCenter.SolarPanel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7676,13 +9843,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 The position at which the thruster generates thrust, in the given reference frame.
 For gimballed engines, this takes into account the current rotation of the gimbal.
- <param name="referenceFrame">
- </param>
+Returns: The position as a vector.
+<param name="referenceFrame">The reference frame that the returned
+position vector is in.</param>
 
 **Parameters**
 
--   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7693,13 +9861,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 The direction of the force generated by the thruster, in the given reference frame.
 This is opposite to the direction in which the thruster expels propellant.
 For gimballed engines, this takes into account the current rotation of the gimbal.
- <param name="referenceFrame">
- </param>
+Returns: The direction as a unit vector.
+<param name="referenceFrame">The reference frame that the returned
+direction is in.</param>
 
 **Parameters**
 
--   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7709,15 +9878,16 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 The position at which the thruster generates thrust, when the engine is in its
 initial position (no gimballing), in the given reference frame.
- <param name="referenceFrame">
- </param>
-This position can move when the gimbal rotates. This is because the thrust position and
+Returns: The position as a vector.
+<param name="referenceFrame">The reference frame that the returned
+position vector is in.</param>
+ This position can move when the gimbal rotates. This is because the thrust position and
 gimbal position are not necessarily the same.
 
 **Parameters**
 
--   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7728,13 +9898,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 The direction of the force generated by the thruster, when the engine is in its
 initial position (no gimballing), in the given reference frame.
 This is opposite to the direction in which the thruster expels propellant.
- <param name="referenceFrame">
- </param>
+Returns: The direction as a unit vector.
+<param name="referenceFrame">The reference frame that the returned
+direction is in.</param>
 
 **Parameters**
 
--   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7743,11 +9914,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Position around which the gimbal pivots.
+Returns: The position as a vector.
+<param name="referenceFrame">The reference frame that the returned
+position vector is in.</param>
 
 **Parameters**
 
--   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7759,7 +9933,7 @@ The [T:SpaceCenter.Part](T:SpaceCenter.Part) that contains this thruster.
 
 **Parameters**
 
--   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster see [Long.js]<https://www.npmjs.com/package/long>
+-   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7771,15 +9945,16 @@ A reference frame that is fixed relative to the thruster and orientated with
 its thrust direction ([M:SpaceCenter.Thruster.ThrustDirection](M:SpaceCenter.Thruster.ThrustDirection)).
 For gimballed engines, this takes into account the current rotation of the gimbal.
 <list type="bullet"><item><description>
-The origin is at the position of thrust for this thruster ([M:SpaceCenter.Thruster.ThrustPosition](M:SpaceCenter.Thruster.ThrustPosition)).
-</description></item><item><description>
+The origin is at the position of thrust for this thruster
+([M:SpaceCenter.Thruster.ThrustPosition](M:SpaceCenter.Thruster.ThrustPosition)).</description></item><item><description>
 The axes rotate with the thrust direction.
 This is the direction in which the thruster expels propellant, including any gimballing.
-</description></item><item><description>The y-axis points along the thrust direction.</description></item><item><description>The x-axis and z-axis are perpendicular to the thrust direction.</description></item></list>
+</description></item><item><description>The y-axis points along the thrust direction.</description></item><item><description>The x-axis and z-axis are perpendicular to the thrust direction.
+</description></item></list>
 
 **Parameters**
 
--   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster see [Long.js]<https://www.npmjs.com/package/long>
+-   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7791,7 +9966,7 @@ Whether the thruster is gimballed.
 
 **Parameters**
 
--   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster see [Long.js]<https://www.npmjs.com/package/long>
+-   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7799,11 +9974,601 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The current gimbal angle in the pitch, roll and yaw axes.
+The current gimbal angle in the pitch, roll and yaw axes, in degrees.
 
 **Parameters**
 
--   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster see [Long.js]<https://www.npmjs.com/package/long>
+-   `thruster` **Long** A long value representing the id for the SpaceCenter.Thruster
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetPart
+
+**Extends SpaceCenter**
+
+The part object for this wheel.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetState
+
+**Extends SpaceCenter**
+
+The current state of the wheel.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetRadius
+
+**Extends SpaceCenter**
+
+Radius of the wheel, in meters.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetGrounded
+
+**Extends SpaceCenter**
+
+Whether the wheel is touching the ground.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetHasBrakes
+
+**Extends SpaceCenter**
+
+Whether the wheel has brakes.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetBrakes
+
+**Extends SpaceCenter**
+
+The braking force, as a percentage of maximum, when the brakes are applied.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelSetBrakes
+
+**Extends SpaceCenter**
+
+The braking force, as a percentage of maximum, when the brakes are applied.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+-   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+Returns **void** 
+
+## wheelGetAutoFrictionControl
+
+**Extends SpaceCenter**
+
+Whether automatic friction control is enabled.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelSetAutoFrictionControl
+
+**Extends SpaceCenter**
+
+Whether automatic friction control is enabled.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## wheelGetManualFrictionControl
+
+**Extends SpaceCenter**
+
+Manual friction control value. Only has an effect if automatic friction control is disabled.
+A value between 0 and 5 inclusive.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelSetManualFrictionControl
+
+**Extends SpaceCenter**
+
+Manual friction control value. Only has an effect if automatic friction control is disabled.
+A value between 0 and 5 inclusive.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+-   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+Returns **void** 
+
+## wheelGetDeployable
+
+**Extends SpaceCenter**
+
+Whether the wheel is deployable.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetDeployed
+
+**Extends SpaceCenter**
+
+Whether the wheel is deployed.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelSetDeployed
+
+**Extends SpaceCenter**
+
+Whether the wheel is deployed.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## wheelGetPowered
+
+**Extends SpaceCenter**
+
+Whether the wheel is powered by a motor.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetMotorEnabled
+
+**Extends SpaceCenter**
+
+Whether the motor is enabled.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelSetMotorEnabled
+
+**Extends SpaceCenter**
+
+Whether the motor is enabled.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## wheelGetMotorInverted
+
+**Extends SpaceCenter**
+
+Whether the direction of the motor is inverted.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelSetMotorInverted
+
+**Extends SpaceCenter**
+
+Whether the direction of the motor is inverted.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## wheelGetMotorState
+
+**Extends SpaceCenter**
+
+Whether the direction of the motor is inverted.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetMotorOutput
+
+**Extends SpaceCenter**
+
+The output of the motor. This is the torque currently being generated, in Newton meters.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetTractionControlEnabled
+
+**Extends SpaceCenter**
+
+Whether automatic traction control is enabled.
+A wheel only has traction control if it is powered.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelSetTractionControlEnabled
+
+**Extends SpaceCenter**
+
+Whether automatic traction control is enabled.
+A wheel only has traction control if it is powered.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## wheelGetTractionControl
+
+**Extends SpaceCenter**
+
+Setting for the traction control.
+Only takes effect if the wheel has automatic traction control enabled.
+A value between 0 and 5 inclusive.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelSetTractionControl
+
+**Extends SpaceCenter**
+
+Setting for the traction control.
+Only takes effect if the wheel has automatic traction control enabled.
+A value between 0 and 5 inclusive.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+-   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+Returns **void** 
+
+## wheelGetDriveLimiter
+
+**Extends SpaceCenter**
+
+Manual setting for the motor limiter.
+Only takes effect if the wheel has automatic traction control disabled.
+A value between 0 and 100 inclusive.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelSetDriveLimiter
+
+**Extends SpaceCenter**
+
+Manual setting for the motor limiter.
+Only takes effect if the wheel has automatic traction control disabled.
+A value between 0 and 100 inclusive.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+-   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+
+Returns **void** 
+
+## wheelGetSteerable
+
+**Extends SpaceCenter**
+
+Whether the wheel has steering.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetSteeringEnabled
+
+**Extends SpaceCenter**
+
+Whether the wheel steering is enabled.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelSetSteeringEnabled
+
+**Extends SpaceCenter**
+
+Whether the wheel steering is enabled.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## wheelGetSteeringInverted
+
+**Extends SpaceCenter**
+
+Whether the wheel steering is inverted.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelSetSteeringInverted
+
+**Extends SpaceCenter**
+
+Whether the wheel steering is inverted.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+-   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
+
+Returns **void** 
+
+## wheelGetHasSuspension
+
+**Extends SpaceCenter**
+
+Whether the wheel has suspension.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetSuspensionSpringStrength
+
+**Extends SpaceCenter**
+
+Suspension spring strength, as set in the editor.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetSuspensionDamperStrength
+
+**Extends SpaceCenter**
+
+Suspension damper strength, as set in the editor.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetBroken
+
+**Extends SpaceCenter**
+
+Whether the wheel is broken.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetRepairable
+
+**Extends SpaceCenter**
+
+Whether the wheel is repairable.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetStress
+
+**Extends SpaceCenter**
+
+Current stress on the wheel.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetStressTolerance
+
+**Extends SpaceCenter**
+
+Stress tolerance of the wheel.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetStressPercentage
+
+**Extends SpaceCenter**
+
+Current stress on the wheel as a percentage of its stress tolerance.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetDeflection
+
+**Extends SpaceCenter**
+
+Current deflection of the wheel.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## wheelGetSlip
+
+**Extends SpaceCenter**
+
+Current slip of the wheel.
+
+**Parameters**
+
+-   `wheel` **Long** A long value representing the id for the SpaceCenter.Wheel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## referenceFrameStaticCreateRelative
+
+**Extends SpaceCenter**
+
+Create a relative reference frame. This is a custom reference frame
+whose components offset the components of a parent reference frame.
+<param name="referenceFrame">The parent reference frame on which to
+base this reference frame.</param>
+<param name="position">The offset of the position of the origin,
+as a position vector. Defaults to <math>(0, 0, 0)</math></param>
+<param name="rotation">The rotation to apply to the parent frames rotation,
+as a quaternion of the form <math>(x, y, z, w)</math>.
+Defaults to <math>(0, 0, 0, 1)</math> (i.e. no rotation)</param>
+<param name="velocity">The linear velocity to offset the parent frame by,
+as a vector pointing in the direction of travel, whose magnitude is the speed in
+meters per second. Defaults to <math>(0, 0, 0)</math>.</param>
+<param name="angularVelocity">The angular velocity to offset the parent frame by,
+as a vector. This vector points in the direction of the axis of rotation,
+and its magnitude is the speed of the rotation in radians per second.
+Defaults to <math>(0, 0, 0)</math>.</param>
+
+**Parameters**
+
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+-   `position` **{number, number, number}** The offset of the position of the origin,
+    as a position vector. Defaults to <math>(0, 0, 0)</math>
+-   `rotation` **{number, number, number, number}** The rotation to apply to the parent frames rotation,
+    as a quaternion of the form <math>(x, y, z, w)</math>.
+    Defaults to <math>(0, 0, 0, 1)</math> (i.e. no rotation)
+-   `velocity` **{number, number, number}** The linear velocity to offset the parent frame by,
+    as a vector pointing in the direction of travel, whose magnitude is the speed in
+    meters per second. Defaults to <math>(0, 0, 0)</math>.
+-   `angularVelocity` **{number, number, number}** The angular velocity to offset the parent frame by,
+    as a vector. This vector points in the direction of the axis of rotation,
+    and its magnitude is the speed of the rotation in radians per second.
+    Defaults to <math>(0, 0, 0)</math>.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## referenceFrameStaticCreateHybrid
+
+**Extends SpaceCenter**
+
+Create a hybrid reference frame. This is a custom reference frame
+whose components inherited from other reference frames.
+
+<param name="velocity">The reference frame providing the linear velocity of the frame.
+</param>
+<param name="angularVelocity">The reference frame providing the angular velocity
+of the frame.</param>
+ The {position} reference frame is required but all other
+reference frames are optional. If omitted, they are set to the
+{position} reference frame.
+
+**Parameters**
+
+-   `position` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+-   `rotation` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+-   `velocity` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+-   `angularVelocity` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7815,7 +10580,7 @@ The name of the resource.
 
 **Parameters**
 
--   `resource` **Long** A long value representing the id for the SpaceCenter.Resource see [Long.js]<https://www.npmjs.com/package/long>
+-   `resource` **Long** A long value representing the id for the SpaceCenter.Resource
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7827,7 +10592,7 @@ The part containing the resource.
 
 **Parameters**
 
--   `resource` **Long** A long value representing the id for the SpaceCenter.Resource see [Long.js]<https://www.npmjs.com/package/long>
+-   `resource` **Long** A long value representing the id for the SpaceCenter.Resource
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7839,7 +10604,7 @@ The total amount of the resource that can be stored in the part.
 
 **Parameters**
 
--   `resource` **Long** A long value representing the id for the SpaceCenter.Resource see [Long.js]<https://www.npmjs.com/package/long>
+-   `resource` **Long** A long value representing the id for the SpaceCenter.Resource
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7851,7 +10616,7 @@ The amount of the resource that is currently stored in the part.
 
 **Parameters**
 
--   `resource` **Long** A long value representing the id for the SpaceCenter.Resource see [Long.js]<https://www.npmjs.com/package/long>
+-   `resource` **Long** A long value representing the id for the SpaceCenter.Resource
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7863,7 +10628,7 @@ The density of the resource, in <math>kg/l</math>.
 
 **Parameters**
 
--   `resource` **Long** A long value representing the id for the SpaceCenter.Resource see [Long.js]<https://www.npmjs.com/package/long>
+-   `resource` **Long** A long value representing the id for the SpaceCenter.Resource
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7875,7 +10640,7 @@ The flow mode of the resource.
 
 **Parameters**
 
--   `resource` **Long** A long value representing the id for the SpaceCenter.Resource see [Long.js]<https://www.npmjs.com/package/long>
+-   `resource` **Long** A long value representing the id for the SpaceCenter.Resource
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7887,7 +10652,7 @@ Whether use of this resource is enabled.
 
 **Parameters**
 
--   `resource` **Long** A long value representing the id for the SpaceCenter.Resource see [Long.js]<https://www.npmjs.com/package/long>
+-   `resource` **Long** A long value representing the id for the SpaceCenter.Resource
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7899,7 +10664,7 @@ Whether use of this resource is enabled.
 
 **Parameters**
 
--   `resource` **Long** A long value representing the id for the SpaceCenter.Resource see [Long.js]<https://www.npmjs.com/package/long>
+-   `resource` **Long** A long value representing the id for the SpaceCenter.Resource
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -7908,16 +10673,17 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-Start transferring a resource transfer between a pair of parts. The transfer will move at most
-&lt;paramref name="maxAmount} units of the resource, depending on how much of the resource is
-available in the source part and how much storage is available in the destination part.
+Start transferring a resource transfer between a pair of parts. The transfer will move
+at most {maxAmount} units of the resource, depending on how much of
+the resource is available in the source part and how much storage is available in the
+destination part.
 Use [M:SpaceCenter.ResourceTransfer.Complete](M:SpaceCenter.ResourceTransfer.Complete) to check if the transfer is complete.
 Use [M:SpaceCenter.ResourceTransfer.Amount](M:SpaceCenter.ResourceTransfer.Amount) to see how much of the resource has been transferred.
 
 **Parameters**
 
--   `fromPart` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
--   `toPart` **Long** A long value representing the id for the SpaceCenter.Part see [Long.js]<https://www.npmjs.com/package/long>
+-   `fromPart` **Long** A long value representing the id for the SpaceCenter.Part
+-   `toPart` **Long** A long value representing the id for the SpaceCenter.Part
 -   `resource` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of the resource to transfer.
 -   `maxAmount` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** The maximum amount of resource to transfer.
 
@@ -7931,7 +10697,7 @@ Whether the transfer has completed.
 
 **Parameters**
 
--   `resourceTransfer` **Long** A long value representing the id for the SpaceCenter.ResourceTransfer see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceTransfer` **Long** A long value representing the id for the SpaceCenter.ResourceTransfer
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7943,7 +10709,7 @@ The amount of the resource that has been transferred.
 
 **Parameters**
 
--   `resourceTransfer` **Long** A long value representing the id for the SpaceCenter.ResourceTransfer see [Long.js]<https://www.npmjs.com/package/long>
+-   `resourceTransfer` **Long** A long value representing the id for the SpaceCenter.ResourceTransfer
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -7955,7 +10721,7 @@ All the individual resources with the given name that can be stored.
 
 **Parameters**
 
--   `resources` **Long** A long value representing the id for the SpaceCenter.Resources see [Long.js]<https://www.npmjs.com/package/long>
+-   `resources` **Long** A long value representing the id for the SpaceCenter.Resources
 -   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -7968,7 +10734,7 @@ Check whether the named resource can be stored.
 
 **Parameters**
 
--   `resources` **Long** A long value representing the id for the SpaceCenter.Resources see [Long.js]<https://www.npmjs.com/package/long>
+-   `resources` **Long** A long value representing the id for the SpaceCenter.Resources
 -   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of the resource.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -7981,7 +10747,7 @@ Returns the amount of a resource that can be stored.
 
 **Parameters**
 
--   `resources` **Long** A long value representing the id for the SpaceCenter.Resources see [Long.js]<https://www.npmjs.com/package/long>
+-   `resources` **Long** A long value representing the id for the SpaceCenter.Resources
 -   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of the resource.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -7994,7 +10760,7 @@ Returns the amount of a resource that is currently stored.
 
 **Parameters**
 
--   `resources` **Long** A long value representing the id for the SpaceCenter.Resources see [Long.js]<https://www.npmjs.com/package/long>
+-   `resources` **Long** A long value representing the id for the SpaceCenter.Resources
 -   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of the resource.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -8003,7 +10769,7 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Returns the density of a resource, in kg/l.
+Returns the density of a resource, in <math>kg/l</math>.
 
 **Parameters**
 
@@ -8031,7 +10797,7 @@ All the individual resources that can be stored.
 
 **Parameters**
 
--   `resources` **Long** A long value representing the id for the SpaceCenter.Resources see [Long.js]<https://www.npmjs.com/package/long>
+-   `resources` **Long** A long value representing the id for the SpaceCenter.Resources
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8043,7 +10809,7 @@ A list of resource names that can be stored.
 
 **Parameters**
 
--   `resources` **Long** A long value representing the id for the SpaceCenter.Resources see [Long.js]<https://www.npmjs.com/package/long>
+-   `resources` **Long** A long value representing the id for the SpaceCenter.Resources
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8052,11 +10818,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Whether use of all the resources are enabled.
-This is true if all of the resources are enabled. If any of the resources are not enabled, this is false.
+ This is true if all of the resources are enabled.
+If any of the resources are not enabled, this is false.
 
 **Parameters**
 
--   `resources` **Long** A long value representing the id for the SpaceCenter.Resources see [Long.js]<https://www.npmjs.com/package/long>
+-   `resources` **Long** A long value representing the id for the SpaceCenter.Resources
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8065,11 +10832,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Whether use of all the resources are enabled.
-This is true if all of the resources are enabled. If any of the resources are not enabled, this is false.
+ This is true if all of the resources are enabled.
+If any of the resources are not enabled, this is false.
 
 **Parameters**
 
--   `resources` **Long** A long value representing the id for the SpaceCenter.Resources see [Long.js]<https://www.npmjs.com/package/long>
+-   `resources` **Long** A long value representing the id for the SpaceCenter.Resources
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -8082,7 +10850,7 @@ Recover the vessel.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **void** 
 
@@ -8092,14 +10860,15 @@ Returns **void**
 
 Returns a [T:SpaceCenter.Flight](T:SpaceCenter.Flight) object that can be used to get flight
 telemetry for the vessel, in the specified reference frame.
- <param name="referenceFrame">
-Reference frame. Defaults to the vessel's surface reference frame ([M:SpaceCenter.Vessel.SurfaceReferenceFrame](M:SpaceCenter.Vessel.SurfaceReferenceFrame)).
+<param name="referenceFrame">
+Reference frame. Defaults to the vessel's surface reference frame
+([M:SpaceCenter.Vessel.SurfaceReferenceFrame](M:SpaceCenter.Vessel.SurfaceReferenceFrame)).
 </param>
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8108,14 +10877,15 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 Returns a [T:SpaceCenter.Resources](T:SpaceCenter.Resources) object, that can used to get
-information about resources stored in a given &lt;paramref name="stage}.
-  <param name="cumulative">When <c>false</c>, returns the resources for parts
-decoupled in just the given stage. When <c>true</c> returns the resources decoupled in
+information about resources stored in a given {stage}.
+
+<param name="cumulative">When false, returns the resources for parts
+decoupled in just the given stage. When true returns the resources decoupled in
 the given stage and all subsequent stages combined.</param>
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 -   `stage` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Get resources for parts that are decoupled in this stage.
 -   `cumulative` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** When <c>false</c>, returns the resources for parts
     decoupled in just the given stage. When <c>true</c> returns the resources decoupled in
@@ -8127,14 +10897,32 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Returns the position vector of the center of mass of the vessel in the given reference frame.
- <param name="referenceFrame">
- </param>
+The position of the center of mass of the vessel, in the given reference frame.
+Returns: The position as a vector.
+<param name="referenceFrame">The reference frame that the returned
+position vector is in.</param>
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## vesselBoundingBox
+
+**Extends SpaceCenter**
+
+The axis-aligned bounding box of the vessel in the given reference frame.
+Returns: The positions of the minimum and maximum vertices of the box,
+as position vectors.
+<param name="referenceFrame">The reference frame that the returned
+position vectors are in.</param>
+
+**Parameters**
+
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8142,14 +10930,16 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Returns the velocity vector of the center of mass of the vessel in the given reference frame.
- <param name="referenceFrame">
- </param>
+The velocity of the center of mass of the vessel, in the given reference frame.
+Returns: The velocity as a vector. The vector points in the direction of travel,
+and its magnitude is the speed of the body in meters per second.
+<param name="referenceFrame">The reference frame that the returned
+velocity vector is in.</param>
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8157,14 +10947,15 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Returns the rotation of the center of mass of the vessel in the given reference frame.
- <param name="referenceFrame">
- </param>
+The rotation of the vessel, in the given reference frame.
+Returns: The rotation as a quaternion of the form <math>(x, y, z, w)</math>.
+<param name="referenceFrame">The reference frame that the returned
+rotation is in.</param>
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8172,14 +10963,15 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Returns the direction in which the vessel is pointing, as a unit vector, in the given reference frame.
- <param name="referenceFrame">
- </param>
+The direction in which the vessel is pointing, in the given reference frame.
+Returns: The direction as a unit vector.
+<param name="referenceFrame">The reference frame that the returned
+direction is in.</param>
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8187,16 +10979,17 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Returns the angular velocity of the vessel in the given reference frame. The magnitude of the returned
-vector is the rotational speed in radians per second, and the direction of the vector indicates the
-axis of rotation (using the right hand rule).
- <param name="referenceFrame">
- </param>
+The angular velocity of the vessel, in the given reference frame.
+Returns: The angular velocity as a vector. The magnitude of the vector is the rotational
+speed of the vessel, in radians per second. The direction of the vector indicates the
+axis of rotation, using the right-hand rule.
+<param name="referenceFrame">The reference frame the returned
+angular velocity is in.</param>
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
--   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
+-   `referenceFrame` **Long** A long value representing the id for the SpaceCenter.ReferenceFrame
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8208,7 +11001,7 @@ The name of the vessel.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8220,7 +11013,7 @@ The name of the vessel.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -8233,7 +11026,7 @@ The type of the vessel.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8245,8 +11038,8 @@ The type of the vessel.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.VesselType see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
+-   `value` **Long** A long value representing the id for the SpaceCenter.VesselType
 
 Returns **void** 
 
@@ -8258,7 +11051,7 @@ The situation the vessel is in.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8270,7 +11063,7 @@ Whether the vessel is recoverable.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8282,7 +11075,7 @@ The mission elapsed time in seconds.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8294,7 +11087,7 @@ The name of the biome the vessel is currently in.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8306,7 +11099,7 @@ The current orbit of the vessel.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8320,7 +11113,20 @@ RCS and thrust.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## vesselGetComms
+
+**Extends SpaceCenter**
+
+Returns a [T:SpaceCenter.Comms](T:SpaceCenter.Comms) object that can be used to interact
+with CommNet for this vessel.
+
+**Parameters**
+
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8333,7 +11139,43 @@ simple auto-piloting of the vessel.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## vesselGetCrewCapacity
+
+**Extends SpaceCenter**
+
+The number of crew that can occupy the vessel.
+
+**Parameters**
+
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## vesselGetCrewCount
+
+**Extends SpaceCenter**
+
+The number of crew that are occupying the vessel.
+
+**Parameters**
+
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## vesselGetCrew
+
+**Extends SpaceCenter**
+
+The crew in the vessel.
+
+**Parameters**
+
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8346,7 +11188,7 @@ about resources stored in the vessel.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8358,7 +11200,7 @@ A [T:SpaceCenter.Parts](T:SpaceCenter.Parts) object, that can used to interact w
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8370,7 +11212,7 @@ The total mass of the vessel, including resources, in kg.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8382,7 +11224,7 @@ The total mass of the vessel, excluding resources, in kg.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8396,7 +11238,7 @@ every engine in the vessel.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8410,7 +11252,7 @@ active engines, in Newtons. This is computed by summing
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8424,7 +11266,7 @@ engines, in Newtons. This is computed by summing
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8438,7 +11280,7 @@ summing [M:SpaceCenter.Engine.MaxVacuumThrust](M:SpaceCenter.Engine.MaxVacuumThr
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8447,11 +11289,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The combined specific impulse of all active engines, in seconds. This is computed using the formula
-<a href="http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse#Multiple_engines">described here</a>.
+<a href="https://wiki.kerbalspaceprogram.com/wiki/Specific_impulse#Multiple_engines">described here</a>.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8460,11 +11302,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The combined vacuum specific impulse of all active engines, in seconds. This is computed using the formula
-<a href="http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse#Multiple_engines">described here</a>.
+<a href="https://wiki.kerbalspaceprogram.com/wiki/Specific_impulse#Multiple_engines">described here</a>.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8474,11 +11316,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 The combined specific impulse of all active engines at sea level on Kerbin, in seconds.
 This is computed using the formula
-<a href="http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse#Multiple_engines">described here</a>.
+<a href="https://wiki.kerbalspaceprogram.com/wiki/Specific_impulse#Multiple_engines">described here</a>.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8487,12 +11329,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends SpaceCenter**
 
 The moment of inertia of the vessel around its center of mass in <math>kg.m^2</math>.
-The inertia values are around the pitch, roll and yaw directions respectively.
-This corresponds to the vessels reference frame ([M:SpaceCenter.Vessel.ReferenceFrame](M:SpaceCenter.Vessel.ReferenceFrame)).
+The inertia values in the returned 3-tuple are around the
+pitch, roll and yaw directions respectively.
+This corresponds to the vessels reference frame ([T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame)).
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8500,12 +11343,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The inertia tensor of the vessel around its center of mass, in the vessels reference frame ([M:SpaceCenter.Vessel.ReferenceFrame](M:SpaceCenter.Vessel.ReferenceFrame)).
+The inertia tensor of the vessel around its center of mass,
+in the vessels reference frame ([T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame)).
 Returns the 3x3 matrix as a list of elements, in row-major order.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8513,15 +11357,15 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The maximum torque that the vessel generate. Includes contributions from reaction wheels,
-RCS, gimballed engines and aerodynamic control surfaces.
+The maximum torque that the vessel generates. Includes contributions from
+reaction wheels, RCS, gimballed engines and aerodynamic control surfaces.
 Returns the torques in <math>N.m</math> around each of the coordinate axes of the
-vessels reference frame ([M:SpaceCenter.Vessel.ReferenceFrame](M:SpaceCenter.Vessel.ReferenceFrame)).
+vessels reference frame ([T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame)).
 These axes are equivalent to the pitch, roll and yaw axes of the vessel.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8531,12 +11375,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 The maximum torque that the currently active and powered reaction wheels can generate.
 Returns the torques in <math>N.m</math> around each of the coordinate axes of the
-vessels reference frame ([M:SpaceCenter.Vessel.ReferenceFrame](M:SpaceCenter.Vessel.ReferenceFrame)).
+vessels reference frame ([T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame)).
 These axes are equivalent to the pitch, roll and yaw axes of the vessel.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8546,12 +11390,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 The maximum torque that the currently active RCS thrusters can generate.
 Returns the torques in <math>N.m</math> around each of the coordinate axes of the
-vessels reference frame ([M:SpaceCenter.Vessel.ReferenceFrame](M:SpaceCenter.Vessel.ReferenceFrame)).
+vessels reference frame ([T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame)).
 These axes are equivalent to the pitch, roll and yaw axes of the vessel.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8561,12 +11405,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 The maximum torque that the currently active and gimballed engines can generate.
 Returns the torques in <math>N.m</math> around each of the coordinate axes of the
-vessels reference frame ([M:SpaceCenter.Vessel.ReferenceFrame](M:SpaceCenter.Vessel.ReferenceFrame)).
+vessels reference frame ([T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame)).
 These axes are equivalent to the pitch, roll and yaw axes of the vessel.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8576,12 +11420,28 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 The maximum torque that the aerodynamic control surfaces can generate.
 Returns the torques in <math>N.m</math> around each of the coordinate axes of the
-vessels reference frame ([M:SpaceCenter.Vessel.ReferenceFrame](M:SpaceCenter.Vessel.ReferenceFrame)).
+vessels reference frame ([T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame)).
 These axes are equivalent to the pitch, roll and yaw axes of the vessel.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## vesselGetAvailableOtherTorque
+
+**Extends SpaceCenter**
+
+The maximum torque that parts (excluding reaction wheels, gimballed engines,
+RCS and control surfaces) can generate.
+Returns the torques in <math>N.m</math> around each of the coordinate axes of the
+vessels reference frame ([T:SpaceCenter.ReferenceFrame](T:SpaceCenter.ReferenceFrame)).
+These axes are equivalent to the pitch, roll and yaw axes of the vessel.
+
+**Parameters**
+
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8589,12 +11449,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The reference frame that is fixed relative to the vessel, and orientated with the vessel.
+The reference frame that is fixed relative to the vessel,
+and orientated with the vessel.
 <list type="bullet"><item><description>The origin is at the center of mass of the vessel.</description></item><item><description>The axes rotate with the vessel.</description></item><item><description>The x-axis points out to the right of the vessel.</description></item><item><description>The y-axis points in the forward direction of the vessel.</description></item><item><description>The z-axis points out of the bottom off the vessel.</description></item></list>
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8602,13 +11463,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The reference frame that is fixed relative to the vessel, and orientated with the vessels
-orbital prograde/normal/radial directions.
-<list type="bullet"><item><description>The origin is at the center of mass of the vessel.</description></item><item><description>The axes rotate with the orbital prograde/normal/radial directions.</description></item><item><description>The x-axis points in the orbital anti-radial direction.</description></item><item><description>The y-axis points in the orbital prograde direction.</description></item><item><description>The z-axis points in the orbital normal direction.</description></item></list> Be careful not to confuse this with 'orbit' mode on the navball.
+The reference frame that is fixed relative to the vessel,
+and orientated with the vessels orbital prograde/normal/radial directions.
+<list type="bullet"><item><description>The origin is at the center of mass of the vessel.</description></item><item><description>The axes rotate with the orbital prograde/normal/radial directions.</description></item><item><description>The x-axis points in the orbital anti-radial direction.</description></item><item><description>The y-axis points in the orbital prograde direction.</description></item><item><description>The z-axis points in the orbital normal direction.</description></item></list><remarks>
+Be careful not to confuse this with 'orbit' mode on the navball.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8616,19 +11478,20 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The reference frame that is fixed relative to the vessel, and orientated with the surface
-of the body being orbited.
+The reference frame that is fixed relative to the vessel,
+and orientated with the surface of the body being orbited.
 <list type="bullet"><item><description>The origin is at the center of mass of the vessel.</description></item><item><description>The axes rotate with the north and up directions on the surface of the body.</description></item><item><description>The x-axis points in the <a href="https://en.wikipedia.org/wiki/Zenith">zenith</a>
 direction (upwards, normal to the body being orbited, from the center of the body towards the center of
 mass of the vessel).</description></item><item><description>The y-axis points northwards towards the
 <a href="https://en.wikipedia.org/wiki/Horizon">astronomical horizon</a> (north, and tangential to the
 surface of the body -- the direction in which a compass would point when on the surface).</description></item><item><description>The z-axis points eastwards towards the
 <a href="https://en.wikipedia.org/wiki/Horizon">astronomical horizon</a> (east, and tangential to the
-surface of the body -- east on a compass when on the surface).</description></item></list> Be careful not to confuse this with 'surface' mode on the navball.
+surface of the body -- east on a compass when on the surface).</description></item></list><remarks>
+Be careful not to confuse this with 'surface' mode on the navball.
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8636,15 +11499,16 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The reference frame that is fixed relative to the vessel, and orientated with the velocity
-vector of the vessel relative to the surface of the body being orbited.
+The reference frame that is fixed relative to the vessel,
+and orientated with the velocity vector of the vessel relative
+to the surface of the body being orbited.
 <list type="bullet"><item><description>The origin is at the center of mass of the vessel.</description></item><item><description>The axes rotate with the vessel's velocity vector.</description></item><item><description>The y-axis points in the direction of the vessel's velocity vector,
 relative to the surface of the body being orbited.</description></item><item><description>The z-axis is in the plane of the
 <a href="https://en.wikipedia.org/wiki/Horizon">astronomical horizon</a>.</description></item><item><description>The x-axis is orthogonal to the other two axes.</description></item></list>
 
 **Parameters**
 
--   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel see [Long.js]<https://www.npmjs.com/package/long>
+-   `vessel` **Long** A long value representing the id for the SpaceCenter.Vessel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8656,7 +11520,7 @@ Removes the waypoint.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 
 Returns **void** 
 
@@ -8664,11 +11528,11 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-Celestial body the waypoint is attached to.
+The celestial body the waypoint is attached to.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8676,12 +11540,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Celestial body the waypoint is attached to.
+The celestial body the waypoint is attached to.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
+-   `value` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 
 Returns **void** 
 
@@ -8689,11 +11553,11 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-Name of the waypoint as it appears on the map and the contract.
+The name of the waypoint as it appears on the map and the contract.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8701,11 +11565,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-Name of the waypoint as it appears on the map and the contract.
+The name of the waypoint as it appears on the map and the contract.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -8718,7 +11582,7 @@ The seed of the icon color. See [M:SpaceCenter.WaypointManager.Colors](M:SpaceCe
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8730,7 +11594,7 @@ The seed of the icon color. See [M:SpaceCenter.WaypointManager.Colors](M:SpaceCe
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -8743,7 +11607,7 @@ The icon of the waypoint.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8755,7 +11619,7 @@ The icon of the waypoint.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -8768,7 +11632,7 @@ The latitude of the waypoint.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8780,7 +11644,7 @@ The latitude of the waypoint.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -8793,7 +11657,7 @@ The longitude of the waypoint.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8805,7 +11669,7 @@ The longitude of the waypoint.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -8818,7 +11682,7 @@ The altitude of the waypoint above sea level, in meters.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8830,7 +11694,7 @@ The altitude of the waypoint above sea level, in meters.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -8839,11 +11703,12 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-The altitude of the waypoint above the surface of the body or sea level, whichever is closer, in meters.
+The altitude of the waypoint above the surface of the body or sea level,
+whichever is closer, in meters.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8851,11 +11716,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The altitude of the waypoint above the surface of the body or sea level, whichever is closer, in meters.
+The altitude of the waypoint above the surface of the body or sea level,
+whichever is closer, in meters.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -8864,11 +11730,12 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-The altitude of the waypoint above the surface of the body, in meters. When over water, this is the altitude above the sea floor.
+The altitude of the waypoint above the surface of the body, in meters.
+When over water, this is the altitude above the sea floor.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8876,11 +11743,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The altitude of the waypoint above the surface of the body, in meters. When over water, this is the altitude above the sea floor.
+The altitude of the waypoint above the surface of the body, in meters.
+When over water, this is the altitude above the sea floor.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -8889,11 +11757,11 @@ Returns **void**
 
 **Extends SpaceCenter**
 
-True if waypoint is a point near or on the body rather than high in orbit.
+<summary>true if the waypoint is near to the surface of a body.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8901,11 +11769,11 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-True if waypoint is actually glued to the ground.
+<summary>true if the waypoint is attached to the ground.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8913,14 +11781,15 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-The integer index of this waypoint amongst its cluster of sibling waypoints.
-In other words, when you have a cluster of waypoints called "Somewhere Alpha", "Somewhere Beta", and "Somewhere Gamma",
-then the alpha site has index 0, the beta site has index 1 and the gamma site has index 2.
-When [M:SpaceCenter.Waypoint.Clustered](M:SpaceCenter.Waypoint.Clustered) is false, this value is zero but meaningless.
+The integer index of this waypoint within its cluster of sibling waypoints.
+In other words, when you have a cluster of waypoints called "Somewhere Alpha",
+"Somewhere Beta" and "Somewhere Gamma", the alpha site has index 0, the beta
+site has index 1 and the gamma site has index 2.
+When [M:SpaceCenter.Waypoint.Clustered](M:SpaceCenter.Waypoint.Clustered) is false, this is zero.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8928,12 +11797,14 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 **Extends SpaceCenter**
 
-True if this waypoint is part of a set of clustered waypoints with greek letter names appended (Alpha, Beta, Gamma, etc).
-If true, there is a one-to-one correspondence with the greek letter name and the [M:SpaceCenter.Waypoint.Index](M:SpaceCenter.Waypoint.Index).
+<summary>true if this waypoint is part of a set of clustered waypoints with greek letter
+names appended (Alpha, Beta, Gamma, etc).
+If true, there is a one-to-one correspondence with the greek letter name and
+the [M:SpaceCenter.Waypoint.Index](M:SpaceCenter.Waypoint.Index).
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8945,20 +11816,19 @@ Whether the waypoint belongs to a contract.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
-## waypointGetContractId
+## waypointGetContract
 
 **Extends SpaceCenter**
 
-The id of the associated contract.
-Returns 0 if the waypoint does not belong to a contract.
+The associated contract.
 
 **Parameters**
 
--   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypoint` **Long** A long value representing the id for the SpaceCenter.Waypoint
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -8968,15 +11838,35 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 
 Creates a waypoint at the given position at ground level, and returns a
 [T:SpaceCenter.Waypoint](T:SpaceCenter.Waypoint) object that can be used to modify it.
-     <returns>
- </returns>
+
+Returns:
 
 **Parameters**
 
--   `waypointManager` **Long** A long value representing the id for the SpaceCenter.WaypointManager see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypointManager` **Long** A long value representing the id for the SpaceCenter.WaypointManager
 -   `latitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Latitude of the waypoint.
 -   `longitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Longitude of the waypoint.
--   `body` **Long** A long value representing the id for the SpaceCenter.CelestialBody see [Long.js]<https://www.npmjs.com/package/long>
+-   `body` **Long** A long value representing the id for the SpaceCenter.CelestialBody
+-   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the waypoint.
+
+Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
+
+## waypointManagerAddWaypointAtAltitude
+
+**Extends SpaceCenter**
+
+Creates a waypoint at the given position and altitude, and returns a
+[T:SpaceCenter.Waypoint](T:SpaceCenter.Waypoint) object that can be used to modify it.
+
+Returns:
+
+**Parameters**
+
+-   `waypointManager` **Long** A long value representing the id for the SpaceCenter.WaypointManager
+-   `latitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Latitude of the waypoint.
+-   `longitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Longitude of the waypoint.
+-   `altitude` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Altitude (above sea level) of the waypoint.
+-   `body` **Long** A long value representing the id for the SpaceCenter.CelestialBody
 -   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Name of the waypoint.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -8989,7 +11879,7 @@ A list of all existing waypoints.
 
 **Parameters**
 
--   `waypointManager` **Long** A long value representing the id for the SpaceCenter.WaypointManager see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypointManager` **Long** A long value representing the id for the SpaceCenter.WaypointManager
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -9001,7 +11891,7 @@ Returns all available icons (from "GameData/Squad/Contracts/Icons/").
 
 **Parameters**
 
--   `waypointManager` **Long** A long value representing the id for the SpaceCenter.WaypointManager see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypointManager` **Long** A long value representing the id for the SpaceCenter.WaypointManager
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -9014,6 +11904,6 @@ Any other integers may be used as seed.
 
 **Parameters**
 
--   `waypointManager` **Long** A long value representing the id for the SpaceCenter.WaypointManager see [Long.js]<https://www.npmjs.com/package/long>
+-   `waypointManager` **Long** A long value representing the id for the SpaceCenter.WaypointManager
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 

--- a/documentation/ui.md
+++ b/documentation/ui.md
@@ -4,7 +4,8 @@
 
 ## UI
 
-Provides functionality for drawing and interacting with in-game user interface elements. For drawing 3D objects in the flight scene, see the Drawing service.
+Provides functionality for drawing and interacting with in-game user interface elements.
+ For drawing 3D objects in the flight scene, see the Drawing service.
 
 Returns **void** 
 
@@ -13,7 +14,7 @@ Returns **void**
 **Extends UI**
 
 Add a new canvas.
-If you want to add UI elements to KSPs stock UI canvas, use [M:UI.StockCanvas](M:UI.StockCanvas).
+ If you want to add UI elements to KSPs stock UI canvas, use [M:UI.StockCanvas](M:UI.StockCanvas).
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -22,13 +23,13 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends UI**
 
 Display a message on the screen.
-The message appears just like a stock message, for example quicksave or quickload messages.
+ The message appears just like a stock message, for example quicksave or quickload messages.
 
 **Parameters**
 
 -   `content` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** Message content.
 -   `duration` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** Duration before the message disappears, in seconds.
--   `position` **Long** A long value representing the id for the UI.MessagePosition see [Long.js]<https://www.npmjs.com/package/long>
+-   `position` **Long** A long value representing the id for the UI.MessagePosition
 
 Returns **void** 
 
@@ -60,7 +61,7 @@ Remove the UI object.
 
 **Parameters**
 
--   `button` **Long** A long value representing the id for the UI.Button see [Long.js]<https://www.npmjs.com/package/long>
+-   `button` **Long** A long value representing the id for the UI.Button
 
 Returns **void** 
 
@@ -72,7 +73,7 @@ The rect transform for the text.
 
 **Parameters**
 
--   `button` **Long** A long value representing the id for the UI.Button see [Long.js]<https://www.npmjs.com/package/long>
+-   `button` **Long** A long value representing the id for the UI.Button
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -84,7 +85,7 @@ The text for the button.
 
 **Parameters**
 
--   `button` **Long** A long value representing the id for the UI.Button see [Long.js]<https://www.npmjs.com/package/long>
+-   `button` **Long** A long value representing the id for the UI.Button
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -93,12 +94,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends UI**
 
 Whether the button has been clicked.
-This property is set to true when the user clicks the button.
+ This property is set to true when the user clicks the button.
 A client script should reset the property to false in order to detect subsequent button presses.
 
 **Parameters**
 
--   `button` **Long** A long value representing the id for the UI.Button see [Long.js]<https://www.npmjs.com/package/long>
+-   `button` **Long** A long value representing the id for the UI.Button
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -107,12 +108,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends UI**
 
 Whether the button has been clicked.
-This property is set to true when the user clicks the button.
+ This property is set to true when the user clicks the button.
 A client script should reset the property to false in order to detect subsequent button presses.
 
 **Parameters**
 
--   `button` **Long** A long value representing the id for the UI.Button see [Long.js]<https://www.npmjs.com/package/long>
+-   `button` **Long** A long value representing the id for the UI.Button
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -125,7 +126,7 @@ Whether the UI object is visible.
 
 **Parameters**
 
--   `button` **Long** A long value representing the id for the UI.Button see [Long.js]<https://www.npmjs.com/package/long>
+-   `button` **Long** A long value representing the id for the UI.Button
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -137,7 +138,7 @@ Whether the UI object is visible.
 
 **Parameters**
 
--   `button` **Long** A long value representing the id for the UI.Button see [Long.js]<https://www.npmjs.com/package/long>
+-   `button` **Long** A long value representing the id for the UI.Button
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -150,7 +151,7 @@ Create a new container for user interface elements.
 
 **Parameters**
 
--   `canvas` **Long** A long value representing the id for the UI.Canvas see [Long.js]<https://www.npmjs.com/package/long>
+-   `canvas` **Long** A long value representing the id for the UI.Canvas
 -   `visible` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether the panel is visible.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -163,7 +164,7 @@ Add text to the canvas.
 
 **Parameters**
 
--   `canvas` **Long** A long value representing the id for the UI.Canvas see [Long.js]<https://www.npmjs.com/package/long>
+-   `canvas` **Long** A long value representing the id for the UI.Canvas
 -   `content` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The text.
 -   `visible` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether the text is visible.
 
@@ -177,7 +178,7 @@ Add an input field to the canvas.
 
 **Parameters**
 
--   `canvas` **Long** A long value representing the id for the UI.Canvas see [Long.js]<https://www.npmjs.com/package/long>
+-   `canvas` **Long** A long value representing the id for the UI.Canvas
 -   `visible` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether the input field is visible.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -190,7 +191,7 @@ Add a button to the canvas.
 
 **Parameters**
 
--   `canvas` **Long** A long value representing the id for the UI.Canvas see [Long.js]<https://www.npmjs.com/package/long>
+-   `canvas` **Long** A long value representing the id for the UI.Canvas
 -   `content` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The label for the button.
 -   `visible` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether the button is visible.
 
@@ -204,7 +205,7 @@ Remove the UI object.
 
 **Parameters**
 
--   `canvas` **Long** A long value representing the id for the UI.Canvas see [Long.js]<https://www.npmjs.com/package/long>
+-   `canvas` **Long** A long value representing the id for the UI.Canvas
 
 Returns **void** 
 
@@ -216,7 +217,7 @@ The rect transform for the canvas.
 
 **Parameters**
 
--   `canvas` **Long** A long value representing the id for the UI.Canvas see [Long.js]<https://www.npmjs.com/package/long>
+-   `canvas` **Long** A long value representing the id for the UI.Canvas
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -228,7 +229,7 @@ Whether the UI object is visible.
 
 **Parameters**
 
--   `canvas` **Long** A long value representing the id for the UI.Canvas see [Long.js]<https://www.npmjs.com/package/long>
+-   `canvas` **Long** A long value representing the id for the UI.Canvas
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -240,7 +241,7 @@ Whether the UI object is visible.
 
 **Parameters**
 
--   `canvas` **Long** A long value representing the id for the UI.Canvas see [Long.js]<https://www.npmjs.com/package/long>
+-   `canvas` **Long** A long value representing the id for the UI.Canvas
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -253,7 +254,7 @@ Remove the UI object.
 
 **Parameters**
 
--   `inputField` **Long** A long value representing the id for the UI.InputField see [Long.js]<https://www.npmjs.com/package/long>
+-   `inputField` **Long** A long value representing the id for the UI.InputField
 
 Returns **void** 
 
@@ -265,7 +266,7 @@ The rect transform for the input field.
 
 **Parameters**
 
--   `inputField` **Long** A long value representing the id for the UI.InputField see [Long.js]<https://www.npmjs.com/package/long>
+-   `inputField` **Long** A long value representing the id for the UI.InputField
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -277,7 +278,7 @@ The value of the input field.
 
 **Parameters**
 
--   `inputField` **Long** A long value representing the id for the UI.InputField see [Long.js]<https://www.npmjs.com/package/long>
+-   `inputField` **Long** A long value representing the id for the UI.InputField
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -289,7 +290,7 @@ The value of the input field.
 
 **Parameters**
 
--   `inputField` **Long** A long value representing the id for the UI.InputField see [Long.js]<https://www.npmjs.com/package/long>
+-   `inputField` **Long** A long value representing the id for the UI.InputField
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -299,12 +300,12 @@ Returns **void**
 **Extends UI**
 
 The text component of the input field.
-Use [M:UI.InputField.Value](M:UI.InputField.Value) to get and set the value in the field.
+ Use [M:UI.InputField.Value](M:UI.InputField.Value) to get and set the value in the field.
 This object can be used to alter the style of the input field's text.
 
 **Parameters**
 
--   `inputField` **Long** A long value representing the id for the UI.InputField see [Long.js]<https://www.npmjs.com/package/long>
+-   `inputField` **Long** A long value representing the id for the UI.InputField
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -313,12 +314,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends UI**
 
 Whether the input field has been changed.
-This property is set to true when the user modifies the value of the input field.
+ This property is set to true when the user modifies the value of the input field.
 A client script should reset the property to false in order to detect subsequent changes.
 
 **Parameters**
 
--   `inputField` **Long** A long value representing the id for the UI.InputField see [Long.js]<https://www.npmjs.com/package/long>
+-   `inputField` **Long** A long value representing the id for the UI.InputField
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -327,12 +328,12 @@ Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScrip
 **Extends UI**
 
 Whether the input field has been changed.
-This property is set to true when the user modifies the value of the input field.
+ This property is set to true when the user modifies the value of the input field.
 A client script should reset the property to false in order to detect subsequent changes.
 
 **Parameters**
 
--   `inputField` **Long** A long value representing the id for the UI.InputField see [Long.js]<https://www.npmjs.com/package/long>
+-   `inputField` **Long** A long value representing the id for the UI.InputField
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -345,7 +346,7 @@ Whether the UI object is visible.
 
 **Parameters**
 
--   `inputField` **Long** A long value representing the id for the UI.InputField see [Long.js]<https://www.npmjs.com/package/long>
+-   `inputField` **Long** A long value representing the id for the UI.InputField
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -357,7 +358,7 @@ Whether the UI object is visible.
 
 **Parameters**
 
--   `inputField` **Long** A long value representing the id for the UI.InputField see [Long.js]<https://www.npmjs.com/package/long>
+-   `inputField` **Long** A long value representing the id for the UI.InputField
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -370,7 +371,7 @@ Create a panel within this panel.
 
 **Parameters**
 
--   `panel` **Long** A long value representing the id for the UI.Panel see [Long.js]<https://www.npmjs.com/package/long>
+-   `panel` **Long** A long value representing the id for the UI.Panel
 -   `visible` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether the new panel is visible.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -383,7 +384,7 @@ Add text to the panel.
 
 **Parameters**
 
--   `panel` **Long** A long value representing the id for the UI.Panel see [Long.js]<https://www.npmjs.com/package/long>
+-   `panel` **Long** A long value representing the id for the UI.Panel
 -   `content` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The text.
 -   `visible` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether the text is visible.
 
@@ -397,7 +398,7 @@ Add an input field to the panel.
 
 **Parameters**
 
--   `panel` **Long** A long value representing the id for the UI.Panel see [Long.js]<https://www.npmjs.com/package/long>
+-   `panel` **Long** A long value representing the id for the UI.Panel
 -   `visible` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether the input field is visible.
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
@@ -410,7 +411,7 @@ Add a button to the panel.
 
 **Parameters**
 
--   `panel` **Long** A long value representing the id for the UI.Panel see [Long.js]<https://www.npmjs.com/package/long>
+-   `panel` **Long** A long value representing the id for the UI.Panel
 -   `content` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The label for the button.
 -   `visible` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Whether the button is visible.
 
@@ -424,7 +425,7 @@ Remove the UI object.
 
 **Parameters**
 
--   `panel` **Long** A long value representing the id for the UI.Panel see [Long.js]<https://www.npmjs.com/package/long>
+-   `panel` **Long** A long value representing the id for the UI.Panel
 
 Returns **void** 
 
@@ -436,7 +437,7 @@ The rect transform for the panel.
 
 **Parameters**
 
--   `panel` **Long** A long value representing the id for the UI.Panel see [Long.js]<https://www.npmjs.com/package/long>
+-   `panel` **Long** A long value representing the id for the UI.Panel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -448,7 +449,7 @@ Whether the UI object is visible.
 
 **Parameters**
 
--   `panel` **Long** A long value representing the id for the UI.Panel see [Long.js]<https://www.npmjs.com/package/long>
+-   `panel` **Long** A long value representing the id for the UI.Panel
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -460,7 +461,7 @@ Whether the UI object is visible.
 
 **Parameters**
 
--   `panel` **Long** A long value representing the id for the UI.Panel see [Long.js]<https://www.npmjs.com/package/long>
+-   `panel` **Long** A long value representing the id for the UI.Panel
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 
@@ -473,7 +474,7 @@ Position of the rectangles pivot point relative to the anchors.
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -485,7 +486,7 @@ Position of the rectangles pivot point relative to the anchors.
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 -   `value` **{number, number}** 
 
 Returns **void** 
@@ -498,7 +499,7 @@ Position of the rectangles pivot point relative to the anchors.
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -510,7 +511,7 @@ Position of the rectangles pivot point relative to the anchors.
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -523,7 +524,7 @@ Width and height of the rectangle.
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -535,7 +536,7 @@ Width and height of the rectangle.
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 -   `value` **{number, number}** 
 
 Returns **void** 
@@ -548,7 +549,7 @@ Position of the rectangles upper right corner relative to the anchors.
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -560,7 +561,7 @@ Position of the rectangles upper right corner relative to the anchors.
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 -   `value` **{number, number}** 
 
 Returns **void** 
@@ -573,7 +574,7 @@ Position of the rectangles lower left corner relative to the anchors.
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -585,7 +586,7 @@ Position of the rectangles lower left corner relative to the anchors.
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 -   `value` **{number, number}** 
 
 Returns **void** 
@@ -598,7 +599,7 @@ Set the minimum and maximum anchor points as a fraction of the size of the paren
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 -   `value` **{number, number}** 
 
 Returns **void** 
@@ -611,7 +612,7 @@ The anchor point for the lower left corner of the rectangle defined as a fractio
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -623,7 +624,7 @@ The anchor point for the lower left corner of the rectangle defined as a fractio
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 -   `value` **{number, number}** 
 
 Returns **void** 
@@ -636,7 +637,7 @@ The anchor point for the upper right corner of the rectangle defined as a fracti
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -648,7 +649,7 @@ The anchor point for the upper right corner of the rectangle defined as a fracti
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 -   `value` **{number, number}** 
 
 Returns **void** 
@@ -661,7 +662,7 @@ Location of the pivot point around which the rectangle rotates, defined as a fra
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -673,7 +674,7 @@ Location of the pivot point around which the rectangle rotates, defined as a fra
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 -   `value` **{number, number}** 
 
 Returns **void** 
@@ -686,7 +687,7 @@ Rotation, as a quaternion, of the object around its pivot point.
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -698,7 +699,7 @@ Rotation, as a quaternion, of the object around its pivot point.
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 -   `value` **{number, number, number, number}** 
 
 Returns **void** 
@@ -711,7 +712,7 @@ Scale factor applied to the object in the x, y and z dimensions.
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -723,7 +724,7 @@ Scale factor applied to the object in the x, y and z dimensions.
 
 **Parameters**
 
--   `rectTransform` **Long** A long value representing the id for the UI.RectTransform see [Long.js]<https://www.npmjs.com/package/long>
+-   `rectTransform` **Long** A long value representing the id for the UI.RectTransform
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -736,7 +737,7 @@ Remove the UI object.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 
 Returns **void** 
 
@@ -748,7 +749,7 @@ The rect transform for the text.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -760,7 +761,7 @@ A list of all available fonts.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -772,7 +773,7 @@ The text string
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -784,7 +785,7 @@ The text string
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -797,7 +798,7 @@ Name of the font
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -809,7 +810,7 @@ Name of the font
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 -   `value` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 
 Returns **void** 
@@ -822,7 +823,7 @@ Font size.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -834,7 +835,7 @@ Font size.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -847,7 +848,7 @@ Font style.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -859,8 +860,8 @@ Font style.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the UI.FontStyle see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
+-   `value` **Long** A long value representing the id for the UI.FontStyle
 
 Returns **void** 
 
@@ -872,7 +873,7 @@ Alignment.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -884,8 +885,8 @@ Alignment.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
--   `value` **Long** A long value representing the id for the UI.TextAnchor see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
+-   `value` **Long** A long value representing the id for the UI.TextAnchor
 
 Returns **void** 
 
@@ -897,7 +898,7 @@ Line spacing.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -909,7 +910,7 @@ Line spacing.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 -   `value` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 
 Returns **void** 
@@ -922,7 +923,7 @@ Set the color
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -934,7 +935,7 @@ Set the color
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 -   `value` **{number, number, number}** 
 
 Returns **void** 
@@ -947,7 +948,7 @@ Whether the UI object is visible.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 
 Returns **{call: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), decode: [function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function)}** 
 
@@ -959,7 +960,7 @@ Whether the UI object is visible.
 
 **Parameters**
 
--   `text` **Long** A long value representing the id for the UI.Text see [Long.js]<https://www.npmjs.com/package/long>
+-   `text` **Long** A long value representing the id for the UI.Text
 -   `value` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** 
 
 Returns **void** 

--- a/lib/client.js
+++ b/lib/client.js
@@ -321,7 +321,7 @@ function _addStream(client, procedure, propertyPath, callback) {
         return callback(new Error(util.format('client.streamState.%s was already set. The propertyPath must be unique.', propertyPath)));
     }
     _.set(client.streamState, propertyPath, null);
-    let addStreamCall = client.services.krpc.addStream(procedure.call);
+    let addStreamCall = client.services.krpc.addStream(procedure.call, true);
     client.send(addStreamCall, streamAdded);
 
     function streamAdded(err, response) {

--- a/lib/krpc.proto
+++ b/lib/krpc.proto
@@ -38,6 +38,8 @@ message Request {
 message ProcedureCall {
   string service = 1;
   string procedure = 2;
+  uint32 service_id = 4;
+  uint32 procedure_id = 5;
   repeated Argument arguments = 3;
 }
 
@@ -93,7 +95,8 @@ message Procedure {
   string name = 1;
   repeated Parameter parameters = 2;
   Type return_type = 3;
-  string documentation = 4;
+  bool return_is_nullable = 4;
+  string documentation = 5;
 }
 
 message Parameter {
@@ -149,10 +152,11 @@ message Type {
     ENUMERATION = 101;
 
     // Messages
-    PROCEDURE_CALL = 200;
-    STREAM = 201;
-    STATUS = 202;
-    SERVICES = 203;
+    EVENT = 200;
+    PROCEDURE_CALL = 201;
+    STREAM = 202;
+    STATUS = 203;
+    SERVICES = 204;
 
     // Collections
     TUPLE = 300;
@@ -191,6 +195,10 @@ message Stream {
   uint64 id = 1;
 }
 
+message Event {
+  Stream stream = 1;
+}
+
 message Status {
   string version = 1;
   uint64 bytes_read = 2;
@@ -211,4 +219,16 @@ message Status {
   uint64 stream_rpcs_executed = 17;
   float stream_rpc_rate = 18;
   float time_per_stream_update = 19;
+}
+
+// Multiplexed request messages
+
+message MultiplexedRequest {
+  ConnectionRequest connection_request = 1;
+  Request request = 2;
+}
+
+message MultiplexedResponse {
+  Response response = 1;
+  StreamUpdate stream_update = 2;
 }

--- a/lib/services/drawing.js
+++ b/lib/services/drawing.js
@@ -676,6 +676,26 @@ module.exports.polygonSetMaterial = function polygonSetMaterial(polygon, value) 
 
 /**
  * @augments Drawing
+ * @description A list of all available fonts.
+ * @result {string[]}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.textStaticAvailableFonts = function textStaticAvailableFonts() {
+    let encodedArguments = [];
+    return {
+        call: buildProcedureCall('Drawing', 'Text_static_AvailableFonts', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.List,
+            subTypes: [
+                decoders.string
+            ]
+        }
+    };
+};
+
+/**
+ * @augments Drawing
  * @description Remove the object.
  * @param {Long} text - A long value representing the id for the Drawing.Text
  * @result {void}
@@ -777,29 +797,6 @@ module.exports.textSetRotation = function textSetRotation(text, value) {
     return {
         call: buildProcedureCall('Drawing', 'Text_set_Rotation', encodedArguments),
         decode: null
-    };
-};
-
-/**
- * @augments Drawing
- * @description A list of all available fonts.
- * @param {Long} text - A long value representing the id for the Drawing.Text
- * @result {string[]}
- * @returns {{call :Object, decode: function}}
- */
-module.exports.textGetAvailableFonts = function textGetAvailableFonts(text) {
-    let encodedArguments = [
-        encoders.uInt64(text)
-    ];
-    return {
-        call: buildProcedureCall('Drawing', 'Text_get_AvailableFonts', encodedArguments),
-        decode: {
-            isCollection: true,
-            decode: proto.List,
-            subTypes: [
-                decoders.string
-            ]
-        }
     };
 };
 

--- a/lib/services/infernal-robotics.js
+++ b/lib/services/infernal-robotics.js
@@ -7,7 +7,7 @@ const encoders = require('../encoders');
  * @constructor InfernalRobotics
  * @name InfernalRobotics
  * @description This service provides functionality to interact with
- * <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/104535-105-magic-smoke-industries-infernal-robotics-0214/">Infernal Robotics</a>.
+ * <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/104535-112-magic-smoke-industries-infernal-robotics-202/">Infernal Robotics</a>.
  * @result {void}
  * @returns {void}
  */
@@ -15,7 +15,7 @@ const encoders = require('../encoders');
 
 /**
  * @augments InfernalRobotics
- * @description A list of all the servo groups in the given <paramref name="vessel}.
+ * @description A list of all the servo groups in the given {vessel}.
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @result {Long[]} A list of long values representing the ids for the InfernalRobotics.ServoGroup
  * @returns {{call :Object, decode: function}}
@@ -38,8 +38,8 @@ module.exports.servoGroups = function servoGroups(vessel) {
 
 /**
  * @augments InfernalRobotics
- * @description Returns the servo group in the given <paramref name="vessel} with the given <paramref name="name},
- * or <c>null</c> if none exists. If multiple servo groups have the same name, only one of them is returned.
+ * @description Returns the servo group in the given {vessel} with the given {name},
+ * or null if none exists. If multiple servo groups have the same name, only one of them is returned.
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @param {string} name - Name of servo group to find.
  * @result {Long} A long value representing the id for the InfernalRobotics.ServoGroup
@@ -58,8 +58,8 @@ module.exports.servoGroupWithName = function servoGroupWithName(vessel, name) {
 
 /**
  * @augments InfernalRobotics
- * @description Returns the servo in the given <paramref name="vessel} with the given <paramref name="name} or
- * <c>null</c> if none exists. If multiple servos have the same name, only one of them is returned.
+ * @description Returns the servo in the given {vessel} with the given {name} or
+ * null if none exists. If multiple servos have the same name, only one of them is returned.
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @param {string} name - Name of the servo to find.
  * @result {Long} A long value representing the id for the InfernalRobotics.Servo
@@ -177,8 +177,8 @@ module.exports.servoMovePrevPreset = function servoMovePrevPreset(servo) {
 
 /**
  * @augments InfernalRobotics
- * @description Moves the servo to <paramref name="position} and sets the
- * speed multiplier to <paramref name="speed}.
+ * @description Moves the servo to {position} and sets the
+ * speed multiplier to {speed}.
  * @param {Long} servo - A long value representing the id for the InfernalRobotics.Servo
  * @param {number} position - The position to move the servo to.
  * @param {number} speed - Speed multiplier for the movement.
@@ -642,8 +642,8 @@ module.exports.servoSetIsAxisInverted = function servoSetIsAxisInverted(servo, v
 
 /**
  * @augments InfernalRobotics
- * @description Returns the servo with the given <paramref name="name} from this group,
- * or <c>null</c> if none exists.
+ * @description Returns the servo with the given {name} from this group,
+ * or null if none exists.
  * @param {Long} servoGroup - A long value representing the id for the InfernalRobotics.ServoGroup
  * @param {string} name - Name of servo to find.
  * @result {Long} A long value representing the id for the InfernalRobotics.Servo

--- a/lib/services/kerbal-alarm-clock.js
+++ b/lib/services/kerbal-alarm-clock.js
@@ -7,7 +7,7 @@ const encoders = require('../encoders');
  * @constructor KerbalAlarmClock
  * @name KerbalAlarmClock
  * @description This service provides functionality to interact with
- * <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/22809-12x-kerbal-alarm-clock-v3800-october-12/">Kerbal Alarm Clock</a>.
+ * <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/22809-13x-kerbal-alarm-clock-v3850-may-30/">Kerbal Alarm Clock</a>.
  * @result {void}
  * @returns {void}
  */
@@ -15,7 +15,7 @@ const encoders = require('../encoders');
 
 /**
  * @augments KerbalAlarmClock
- * @description Get the alarm with the given <paramref name="name}, or <c>null</c>
+ * @description Get the alarm with the given {name}, or null
  * if no alarms have that name. If more than one alarm has the name,
  * only returns one of them.
  * @param {string} name - Name of the alarm to search for.
@@ -34,7 +34,7 @@ module.exports.alarmWithName = function alarmWithName(name) {
 
 /**
  * @augments KerbalAlarmClock
- * @description Get a list of alarms of the specified <paramref name="type}.
+ * @description Get a list of alarms of the specified {type}.
  * @param {Long} type - A long value representing the id for the KerbalAlarmClock.AlarmType
  * @result {Long[]} A list of long values representing the ids for the KerbalAlarmClock.Alarm
  * @returns {{call :Object, decode: function}}

--- a/lib/services/krpc.js
+++ b/lib/services/krpc.js
@@ -28,6 +28,21 @@ module.exports.getClientId = function getClientId() {
 
 /**
  * @augments KRPC
+ * @description Returns the name of the current client.
+ * This is an empty string if the client has no name.
+ * @result {string}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.getClientName = function getClientName() {
+    let encodedArguments = [];
+    return {
+        call: buildProcedureCall('KRPC', 'GetClientName', encodedArguments),
+        decode: decoders.string
+    };
+};
+
+/**
+ * @augments KRPC
  * @description Returns some information about the server, such as the version.
  * @result {Object}
  * @returns {{call :Object, decode: function}}
@@ -59,16 +74,54 @@ module.exports.getServices = function getServices() {
  * @augments KRPC
  * @description Add a streaming request and return its identifier.
  * @param {Object} call
+ * @param {boolean} start
  * @result {Object}
  * @returns {{call :Object, decode: function}}
  */
-module.exports.addStream = function addStream(call) {
+module.exports.addStream = function addStream(call, start) {
     let encodedArguments = [
-        {buffer: proto.ProcedureCall.encode(call).finish()}
+        {buffer: proto.ProcedureCall.encode(call).finish()},
+        encoders.bool(start)
     ];
     return {
         call: buildProcedureCall('KRPC', 'AddStream', encodedArguments),
         decode: proto.Stream
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Start a previously added streaming request.
+ * @param {number} id
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.startStream = function startStream(id) {
+    let encodedArguments = [
+        encoders.uInt64(id)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'StartStream', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Set the update rate for a stream in Hz.
+ * @param {number} id
+ * @param {number} rate
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.setStreamRate = function setStreamRate(id, rate) {
+    let encodedArguments = [
+        encoders.uInt64(id),
+        encoders.float(rate)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'SetStreamRate', encodedArguments),
+        decode: null
     };
 };
 
@@ -86,6 +139,23 @@ module.exports.removeStream = function removeStream(id) {
     return {
         call: buildProcedureCall('KRPC', 'RemoveStream', encodedArguments),
         decode: null
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Create an event from a server side expression.
+ * @param {Long} expression - A long value representing the id for the KRPC.Expression
+ * @result {Object}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.addEvent = function addEvent(expression) {
+    let encodedArguments = [
+        encoders.uInt64(expression)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'AddEvent', encodedArguments),
+        decode: proto.Event
     };
 };
 
@@ -135,5 +205,1038 @@ module.exports.getCurrentGameScene = function getCurrentGameScene() {
             3: 'EditorVAB',
             4: 'EditorSPH'
         })
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Whether the game is paused.
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.getPaused = function getPaused() {
+    let encodedArguments = [];
+    return {
+        call: buildProcedureCall('KRPC', 'get_Paused', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Whether the game is paused.
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.setPaused = function setPaused(value) {
+    let encodedArguments = [
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'set_Paused', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description A constant value of double precision floating point type.
+ * @param {number} value
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticConstantDouble = function expressionStaticConstantDouble(value) {
+    let encodedArguments = [
+        encoders.double(value)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_ConstantDouble', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description A constant value of single precision floating point type.
+ * @param {number} value
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticConstantFloat = function expressionStaticConstantFloat(value) {
+    let encodedArguments = [
+        encoders.float(value)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_ConstantFloat', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description A constant value of integer type.
+ * @param {number} value
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticConstantInt = function expressionStaticConstantInt(value) {
+    let encodedArguments = [
+        encoders.sInt32(value)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_ConstantInt', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description A constant value of boolean type.
+ * @param {boolean} value
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticConstantBool = function expressionStaticConstantBool(value) {
+    let encodedArguments = [
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_ConstantBool', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description A constant value of string type.
+ * @param {string} value
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticConstantString = function expressionStaticConstantString(value) {
+    let encodedArguments = [
+        encoders.string(value)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_ConstantString', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description An RPC call.
+ * @param {Object} call
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticCall = function expressionStaticCall(call) {
+    let encodedArguments = [
+        {buffer: proto.ProcedureCall.encode(call).finish()}
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Call', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Equality comparison.
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticEqual = function expressionStaticEqual(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Equal', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Inequality comparison.
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticNotEqual = function expressionStaticNotEqual(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_NotEqual', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Greater than numerical comparison.
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticGreaterThan = function expressionStaticGreaterThan(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_GreaterThan', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Greater than or equal numerical comparison.
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticGreaterThanOrEqual = function expressionStaticGreaterThanOrEqual(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_GreaterThanOrEqual', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Less than numerical comparison.
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticLessThan = function expressionStaticLessThan(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_LessThan', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Less than or equal numerical comparison.
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticLessThanOrEqual = function expressionStaticLessThanOrEqual(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_LessThanOrEqual', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Boolean and operator.
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticAnd = function expressionStaticAnd(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_And', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Boolean or operator.
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticOr = function expressionStaticOr(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Or', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Boolean exclusive-or operator.
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticExclusiveOr = function expressionStaticExclusiveOr(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_ExclusiveOr', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Boolean negation operator.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticNot = function expressionStaticNot(arg) {
+    let encodedArguments = [
+        encoders.uInt64(arg)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Not', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Numerical addition.
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticAdd = function expressionStaticAdd(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Add', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Numerical subtraction.
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticSubtract = function expressionStaticSubtract(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Subtract', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Numerical multiplication.
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticMultiply = function expressionStaticMultiply(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Multiply', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Numerical division.
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticDivide = function expressionStaticDivide(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Divide', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Numerical modulo operator.
+ * 
+ * 
+ * Returns: The remainder of arg0 divided by arg1
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticModulo = function expressionStaticModulo(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Modulo', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Numerical power operator.
+ * 
+ * 
+ * Returns: arg0 raised to the power of arg1, with type of arg0
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticPower = function expressionStaticPower(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Power', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Bitwise left shift.
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticLeftShift = function expressionStaticLeftShift(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_LeftShift', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Bitwise right shift.
+ * @param {Long} arg0 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticRightShift = function expressionStaticRightShift(arg0, arg1) {
+    let encodedArguments = [
+        encoders.uInt64(arg0),
+        encoders.uInt64(arg1)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_RightShift', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Perform a cast to the given type.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @param {Long} type - A long value representing the id for the KRPC.Type
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticCast = function expressionStaticCast(arg, type) {
+    let encodedArguments = [
+        encoders.uInt64(arg),
+        encoders.uInt64(type)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Cast', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description A named parameter of type double.
+ * Returns: A named parameter.
+ * @param {string} name - The name of the parameter.
+ * @param {Long} type - A long value representing the id for the KRPC.Type
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticParameter = function expressionStaticParameter(name, type) {
+    let encodedArguments = [
+        encoders.string(name),
+        encoders.uInt64(type)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Parameter', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description A function.
+ * Returns: A function.
+ * @param {Long[]} parameters - A list of long values representing the ids for the KRPC.Expression
+ * @param {Long} body - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticFunction = function expressionStaticFunction(parameters, body) {
+    let encodedArguments = [
+        {buffer: proto.List.encode(parameters).finish()},
+        encoders.uInt64(body)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Function', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description A function call.
+ * Returns: A function call.
+ * @param {Long} function_ - A long value representing the id for the KRPC.Expression
+ * @param {key : Long} args - The arguments to call the function with.
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticInvoke = function expressionStaticInvoke(function_, args) {
+    let encodedArguments = [
+        encoders.uInt64(function_),
+        {buffer: proto.Dictionary.encode(args).finish()}
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Invoke', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Construct a tuple.
+ * Returns: The tuple.
+ * @param {Long[]} elements - A list of long values representing the ids for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticCreateTuple = function expressionStaticCreateTuple(elements) {
+    let encodedArguments = [
+        {buffer: proto.List.encode(elements).finish()}
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_CreateTuple', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Construct a list.
+ * Returns: The list.
+ * @param {Long[]} values - A list of long values representing the ids for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticCreateList = function expressionStaticCreateList(values) {
+    let encodedArguments = [
+        {buffer: proto.List.encode(values).finish()}
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_CreateList', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Construct a set.
+ * Returns: The set.
+ * @param {Long[]} values - The values. Should all be of the same type.
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticCreateSet = function expressionStaticCreateSet(values) {
+    let encodedArguments = [
+        {buffer: proto.Set.encode(values).finish()}
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_CreateSet', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Construct a dictionary, from a list of corresponding keys and values.
+ * Returns: The dictionary.
+ * @param {Long[]} keys - A list of long values representing the ids for the KRPC.Expression
+ * @param {Long[]} values - A list of long values representing the ids for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticCreateDictionary = function expressionStaticCreateDictionary(keys, values) {
+    let encodedArguments = [
+        {buffer: proto.List.encode(keys).finish()},
+        {buffer: proto.List.encode(values).finish()}
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_CreateDictionary', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Convert a collection to a list.
+ * Returns: The collection as a list.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticToList = function expressionStaticToList(arg) {
+    let encodedArguments = [
+        encoders.uInt64(arg)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_ToList', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Convert a collection to a set.
+ * Returns: The collection as a set.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticToSet = function expressionStaticToSet(arg) {
+    let encodedArguments = [
+        encoders.uInt64(arg)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_ToSet', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Access an element in a tuple, list or dictionary.
+ * Returns: The element.
+ * 
+ * <param name="index">The index of the element to access.
+ * A zero indexed integer for a tuple or list, or a key for a dictionary.</param>
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @param {Long} index - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticGet = function expressionStaticGet(arg, index) {
+    let encodedArguments = [
+        encoders.uInt64(arg),
+        encoders.uInt64(index)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Get', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Number of elements in a collection.
+ * Returns: The number of elements in the collection.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticCount = function expressionStaticCount(arg) {
+    let encodedArguments = [
+        encoders.uInt64(arg)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Count', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Sum all elements of a collection.
+ * Returns: The sum of the elements in the collection.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticSum = function expressionStaticSum(arg) {
+    let encodedArguments = [
+        encoders.uInt64(arg)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Sum', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Maximum of all elements in a collection.
+ * Returns: The maximum elements in the collection.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticMax = function expressionStaticMax(arg) {
+    let encodedArguments = [
+        encoders.uInt64(arg)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Max', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Minimum of all elements in a collection.
+ * Returns: The minimum elements in the collection.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticMin = function expressionStaticMin(arg) {
+    let encodedArguments = [
+        encoders.uInt64(arg)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Min', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Minimum of all elements in a collection.
+ * Returns: The minimum elements in the collection.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticAverage = function expressionStaticAverage(arg) {
+    let encodedArguments = [
+        encoders.uInt64(arg)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Average', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Run a function on every element in the collection.
+ * Returns: The modified collection.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @param {Long} func - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticSelect = function expressionStaticSelect(arg, func) {
+    let encodedArguments = [
+        encoders.uInt64(arg),
+        encoders.uInt64(func)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Select', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Run a function on every element in the collection.
+ * Returns: The modified collection.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @param {Long} func - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticWhere = function expressionStaticWhere(arg, func) {
+    let encodedArguments = [
+        encoders.uInt64(arg),
+        encoders.uInt64(func)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Where', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Determine if a collection contains a value.
+ * Returns: Whether the collection contains a value.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @param {Long} value - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticContains = function expressionStaticContains(arg, value) {
+    let encodedArguments = [
+        encoders.uInt64(arg),
+        encoders.uInt64(value)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Contains', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Applies an accumulator function over a sequence.
+ * Returns: The accumulated value.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @param {Long} func - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticAggregate = function expressionStaticAggregate(arg, func) {
+    let encodedArguments = [
+        encoders.uInt64(arg),
+        encoders.uInt64(func)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Aggregate', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Applies an accumulator function over a sequence, with a given seed.
+ * Returns: The accumulated value.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @param {Long} seed - A long value representing the id for the KRPC.Expression
+ * @param {Long} func - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticAggregateWithSeed = function expressionStaticAggregateWithSeed(arg, seed, func) {
+    let encodedArguments = [
+        encoders.uInt64(arg),
+        encoders.uInt64(seed),
+        encoders.uInt64(func)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_AggregateWithSeed', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Concatenate two sequences.
+ * Returns: The first sequence followed by the second sequence.
+ * @param {Long} arg1 - A long value representing the id for the KRPC.Expression
+ * @param {Long} arg2 - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticConcat = function expressionStaticConcat(arg1, arg2) {
+    let encodedArguments = [
+        encoders.uInt64(arg1),
+        encoders.uInt64(arg2)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Concat', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Order a collection using a key function.
+ * Returns: The ordered collection.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @param {Long} key - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticOrderBy = function expressionStaticOrderBy(arg, key) {
+    let encodedArguments = [
+        encoders.uInt64(arg),
+        encoders.uInt64(key)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_OrderBy', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Determine whether all items in a collection satisfy a boolean predicate.
+ * Returns: Whether all items satisfy the predicate.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @param {Long} predicate - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticAll = function expressionStaticAll(arg, predicate) {
+    let encodedArguments = [
+        encoders.uInt64(arg),
+        encoders.uInt64(predicate)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_All', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Determine whether any item in a collection satisfies a boolean predicate.
+ * Returns: Whether any item satisfies the predicate.
+ * @param {Long} arg - A long value representing the id for the KRPC.Expression
+ * @param {Long} predicate - A long value representing the id for the KRPC.Expression
+ * @result {Long} A long value representing the id for the KRPC.Expression
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.expressionStaticAny = function expressionStaticAny(arg, predicate) {
+    let encodedArguments = [
+        encoders.uInt64(arg),
+        encoders.uInt64(predicate)
+    ];
+    return {
+        call: buildProcedureCall('KRPC', 'Expression_static_Any', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Double type.
+ * @result {Long} A long value representing the id for the KRPC.Type
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.typeStaticDouble = function typeStaticDouble() {
+    let encodedArguments = [];
+    return {
+        call: buildProcedureCall('KRPC', 'Type_static_Double', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Float type.
+ * @result {Long} A long value representing the id for the KRPC.Type
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.typeStaticFloat = function typeStaticFloat() {
+    let encodedArguments = [];
+    return {
+        call: buildProcedureCall('KRPC', 'Type_static_Float', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Int type.
+ * @result {Long} A long value representing the id for the KRPC.Type
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.typeStaticInt = function typeStaticInt() {
+    let encodedArguments = [];
+    return {
+        call: buildProcedureCall('KRPC', 'Type_static_Int', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description Bool type.
+ * @result {Long} A long value representing the id for the KRPC.Type
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.typeStaticBool = function typeStaticBool() {
+    let encodedArguments = [];
+    return {
+        call: buildProcedureCall('KRPC', 'Type_static_Bool', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments KRPC
+ * @description String type.
+ * @result {Long} A long value representing the id for the KRPC.Type
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.typeStaticString = function typeStaticString() {
+    let encodedArguments = [];
+    return {
+        call: buildProcedureCall('KRPC', 'Type_static_String', encodedArguments),
+        decode: decoders.uInt64
     };
 };

--- a/lib/services/remote-tech.js
+++ b/lib/services/remote-tech.js
@@ -7,7 +7,7 @@ const encoders = require('../encoders');
  * @constructor RemoteTech
  * @name RemoteTech
  * @description This service provides functionality to interact with
- * <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/139167-12-remotetech-v180-2016-10-15/">RemoteTech</a>.
+ * <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/139167-13-remotetech-v188-2017-09-03/">RemoteTech</a>.
  * @result {void}
  * @returns {void}
  */

--- a/lib/services/space-center.js
+++ b/lib/services/space-center.js
@@ -29,8 +29,12 @@ module.exports.clearTarget = function clearTarget() {
 
 /**
  * @augments SpaceCenter
- * @description Returns a list of vessels from the given <paramref name="craftDirectory} that can be launched.
- * @param {string} craftDirectory - Name of the directory in the current saves "Ships" directory. For example <c>"VAB"</c> or <c>"SPH"</c>.
+ * @description Returns a list of vessels from the given {craftDirectory}
+ * that can be launched.
+ * <param name="craftDirectory">Name of the directory in the current saves
+ * "Ships" directory. For example "VAB" or "SPH".</param>
+ * @param {string} craftDirectory - Name of the directory in the current saves
+"Ships" directory. For example <c>"VAB"</c> or <c>"SPH"</c>.
  * @result {string[]}
  * @returns {{call :Object, decode: function}}
  */
@@ -53,9 +57,20 @@ module.exports.launchableVessels = function launchableVessels(craftDirectory) {
 /**
  * @augments SpaceCenter
  * @description Launch a vessel.
- * @param {string} craftDirectory - Name of the directory in the current saves "Ships" directory, that contains the craft file. For example <c>"VAB"</c> or <c>"SPH"</c>.
- * @param {string} name - Name of the vessel to launch. This is the name of the ".craft" file in the save directory, without the ".craft" file extension.
- * @param {string} launchSite - Name of the launch site. For example <c>"LaunchPad"</c> or <c>"Runway"</c>.
+ * <param name="craftDirectory">Name of the directory in the current saves
+ * "Ships" directory, that contains the craft file.
+ * For example "VAB" or "SPH".</param>
+ * <param name="name">Name of the vessel to launch. This is the name of the ".craft" file
+ * in the save directory, without the ".craft" file extension.</param>
+ * <param name="launchSite">Name of the launch site. For example "LaunchPad" or
+ * "Runway".</param>
+ * @param {string} craftDirectory - Name of the directory in the current saves
+"Ships" directory, that contains the craft file.
+For example <c>"VAB"</c> or <c>"SPH"</c>.
+ * @param {string} name - Name of the vessel to launch. This is the name of the ".craft" file
+in the save directory, without the ".craft" file extension.
+ * @param {string} launchSite - Name of the launch site. For example <c>"LaunchPad"</c> or
+<c>"Runway"</c>.
  * @result {void}
  * @returns {void}
  */
@@ -74,8 +89,9 @@ module.exports.launchVessel = function launchVessel(craftDirectory, name, launch
 /**
  * @augments SpaceCenter
  * @description Launch a new vessel from the VAB onto the launchpad.
- *
- *  This is equivalent to calling {@link M:SpaceCenter.LaunchVessel} with the craft directory set to "VAB" and the launch site set to "LaunchPad".
+ * 
+ *  This is equivalent to calling {@link M:SpaceCenter.LaunchVessel} with the craft directory
+ * set to "VAB" and the launch site set to "LaunchPad".
  * @param {string} name - Name of the vessel to launch.
  * @result {void}
  * @returns {void}
@@ -93,8 +109,9 @@ module.exports.launchVesselFromVab = function launchVesselFromVab(name) {
 /**
  * @augments SpaceCenter
  * @description Launch a new vessel from the SPH onto the runway.
- *
- *  This is equivalent to calling {@link M:SpaceCenter.LaunchVessel} with the craft directory set to "SPH" and the launch site set to "Runway".
+ * 
+ *  This is equivalent to calling {@link M:SpaceCenter.LaunchVessel} with the craft directory
+ * set to "SPH" and the launch site set to "Runway".
  * @param {string} name - Name of the vessel to launch.
  * @result {void}
  * @returns {void}
@@ -112,7 +129,8 @@ module.exports.launchVesselFromSph = function launchVesselFromSph(name) {
 /**
  * @augments SpaceCenter
  * @description Save the game with a given name.
- * This will create a save file called <c>name.sfs</c> in the folder of the current save game.
+ * This will create a save file called name.sfs in the folder of the
+ * current save game.
  * @param {string} name
  * @result {void}
  * @returns {void}
@@ -130,7 +148,8 @@ module.exports.save = function save(name) {
 /**
  * @augments SpaceCenter
  * @description Load the game with the given name.
- * This will create a load a save file called <c>name.sfs</c> from the folder of the current save game.
+ * This will create a load a save file called name.sfs from the folder of the
+ * current save game.
  * @param {string} name
  * @result {void}
  * @returns {void}
@@ -177,10 +196,11 @@ module.exports.quickload = function quickload() {
 
 /**
  * @augments SpaceCenter
- * @description Returns <c>true</c> if regular "on-rails" time warp can be used, at the specified warp
- * <paramref name="factor}. The maximum time warp rate is limited by various things,
+ * @description Returns true if regular "on-rails" time warp can be used, at the specified warp
+ * {factor}. The maximum time warp rate is limited by various things,
  * including how close the active vessel is to a planet. See
- * <a href="http://wiki.kerbalspaceprogram.com/wiki/Time_warp">the KSP wiki</a> for details.
+ * <a href="https://wiki.kerbalspaceprogram.com/wiki/Time_warp">the KSP wiki</a>
+ * for details.
  * @param {number} factor - The warp factor to check.
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
@@ -198,18 +218,20 @@ module.exports.canRailsWarpAt = function canRailsWarpAt(factor) {
 /**
  * @augments SpaceCenter
  * @description Uses time acceleration to warp forward to a time in the future, specified
- * by universal time <paramref name="ut}. This call blocks until the desired
+ * by universal time {ut}. This call blocks until the desired
  * time is reached. Uses regular "on-rails" or physical time warp as appropriate.
  * For example, physical time warp is used when the active vessel is traveling
  * through an atmosphere. When using regular "on-rails" time warp, the warp
- * rate is limited by <paramref name="maxRailsRate}, and when using physical
- * time warp, the warp rate is limited by <paramref name="maxPhysicsRate}.
- *
- *
- *
- * <returns>When the time warp is complete.</returns>
+ * rate is limited by {maxRailsRate}, and when using physical
+ * time warp, the warp rate is limited by {maxPhysicsRate}.
+ * 
+ * <param name="maxRailsRate">The maximum warp rate in regular "on-rails" time warp.
+ * </param>
+ * 
+ * Returns: When the time warp is complete.
  * @param {number} ut - The universal time to warp to, in seconds.
  * @param {number} maxRailsRate - The maximum warp rate in regular "on-rails" time warp.
+
  * @param {number} maxPhysicsRate - The maximum warp rate in physical time warp.
  * @result {void}
  * @returns {void}
@@ -228,12 +250,15 @@ module.exports.warpTo = function warpTo(ut, maxRailsRate, maxPhysicsRate) {
 
 /**
  * @augments SpaceCenter
- * @description Converts a position vector from one reference frame to another.
- *
- *
- *
- * <returns>The corresponding position vector in reference frame <paramref name="to}.</returns>
- * @param {{number, number, number}} position - Position vector in reference frame <paramref name="from" />.
+ * @description Converts a position from one reference frame to another.
+ * <param name="position">Position, as a vector, in reference frame
+ * {from}.</param>
+ * 
+ * 
+ * Returns: The corresponding position, as a vector, in reference frame
+ * {to}.
+ * @param {{number, number, number}} position - Position, as a vector, in reference frame
+<paramref name="from" />.
  * @param {Long} from - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @param {Long} to - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -261,12 +286,15 @@ module.exports.transformPosition = function transformPosition(position, from, to
 
 /**
  * @augments SpaceCenter
- * @description Converts a direction vector from one reference frame to another.
- *
- *
- *
- * <returns>The corresponding direction vector in reference frame <paramref name="to}.</returns>
- * @param {{number, number, number}} direction - Direction vector in reference frame <paramref name="from" />.
+ * @description Converts a direction from one reference frame to another.
+ * <param name="direction">Direction, as a vector, in reference frame
+ * {from}. </param>
+ * 
+ * 
+ * Returns: The corresponding direction, as a vector, in reference frame
+ * {to}.
+ * @param {{number, number, number}} direction - Direction, as a vector, in reference frame
+<paramref name="from" />. 
  * @param {Long} from - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @param {Long} to - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -295,11 +323,14 @@ module.exports.transformDirection = function transformDirection(direction, from,
 /**
  * @augments SpaceCenter
  * @description Converts a rotation from one reference frame to another.
- *
- *
- *
- * <returns>The corresponding rotation in reference frame <paramref name="to}.</returns>
- * @param {{number, number, number, number}} rotation - Rotation in reference frame <paramref name="from" />.
+ * <param name="rotation">Rotation, as a quaternion of the form <math>(x, y, z, w)</math>,
+ * in reference frame {from}.</param>
+ * 
+ * 
+ * Returns: The corresponding rotation, as a quaternion of the form
+ * <math>(x, y, z, w)</math>, in reference frame {to}.
+ * @param {{number, number, number, number}} rotation - Rotation, as a quaternion of the form <math>(x, y, z, w)</math>,
+in reference frame <paramref name="from" />.
  * @param {Long} from - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @param {Long} to - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number, number}}
@@ -328,16 +359,23 @@ module.exports.transformRotation = function transformRotation(rotation, from, to
 
 /**
  * @augments SpaceCenter
- * @description Converts a velocity vector (acting at the specified position vector) from one
- * reference frame to another. The position vector is required to take the
- * relative angular velocity of the reference frames into account.
- *
- *
- *
- *
- * <returns>The corresponding velocity in reference frame <paramref name="to}.</returns>
- * @param {{number, number, number}} position - Position vector in reference frame <paramref name="from" />.
- * @param {{number, number, number}} velocity - Velocity vector in reference frame <paramref name="from" />.
+ * @description Converts a velocity (acting at the specified position) from one reference frame
+ * to another. The position is required to take the relative angular velocity of the
+ * reference frames into account.
+ * <param name="position">Position, as a vector, in reference frame
+ * {from}.</param>
+ * <param name="velocity">Velocity, as a vector that points in the direction of travel and
+ * whose magnitude is the speed in meters per second, in reference frame
+ * {from}.</param>
+ * 
+ * 
+ * Returns: The corresponding velocity, as a vector, in reference frame
+ * {to}.
+ * @param {{number, number, number}} position - Position, as a vector, in reference frame
+<paramref name="from" />.
+ * @param {{number, number, number}} velocity - Velocity, as a vector that points in the direction of travel and
+whose magnitude is the speed in meters per second, in reference frame
+<paramref name="from" />.
  * @param {Long} from - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @param {Long} to - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -361,6 +399,58 @@ module.exports.transformVelocity = function transformVelocity(position, velocity
                 decoders.double
             ]
         }
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Cast a ray from a given position in a given direction, and return the distance to the hit point.
+ * If no hit occurs, returns infinity.
+ * 
+ * 
+ * 
+ * Returns: The distance to the hit, in meters, or infinity if there was no hit.
+ * @param {{number, number, number}} position - Position, as a vector, of the origin of the ray.
+ * @param {{number, number, number}} direction - Direction of the ray, as a unit vector.
+ * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.raycastDistance = function raycastDistance(position, direction, referenceFrame) {
+    let encodedArguments = [
+        {buffer: proto.Tuple.encode(position).finish()},
+        {buffer: proto.Tuple.encode(direction).finish()},
+        encoders.uInt64(referenceFrame)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'RaycastDistance', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Cast a ray from a given position in a given direction, and return the part that it hits.
+ * If no hit occurs, returns null.
+ * 
+ * 
+ * 
+ * Returns: The part that was hit or null if there was no hit.
+ * @param {{number, number, number}} position - Position, as a vector, of the origin of the ray.
+ * @param {{number, number, number}} direction - Direction of the ray, as a unit vector.
+ * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
+ * @result {Long} A long value representing the id for the SpaceCenter.Part
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.raycastPart = function raycastPart(position, direction, referenceFrame) {
+    let encodedArguments = [
+        {buffer: proto.Tuple.encode(position).finish()},
+        {buffer: proto.Tuple.encode(direction).finish()},
+        encoders.uInt64(referenceFrame)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'RaycastPart', encodedArguments),
+        decode: decoders.uInt64
     };
 };
 
@@ -546,6 +636,20 @@ module.exports.getWaypointManager = function getWaypointManager() {
 
 /**
  * @augments SpaceCenter
+ * @description The contract manager.
+ * @result {Long} A long value representing the id for the SpaceCenter.ContractManager
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.getContractManager = function getContractManager() {
+    let encodedArguments = [];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'get_ContractManager', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments SpaceCenter
  * @description An object that can be used to control the camera.
  * @result {Long} A long value representing the id for the SpaceCenter.Camera
  * @returns {{call :Object, decode: function}}
@@ -636,8 +740,8 @@ module.exports.getUt = function getUt() {
 
 /**
  * @augments SpaceCenter
- * @description The value of the <a href="https://en.wikipedia.org/wiki/Gravitational_constant">gravitational constant</a>
- * G in <math>N(m/kg)^2</math>.
+ * @description The value of the <a href="https://en.wikipedia.org/wiki/Gravitational_constant">
+ * gravitational constant</a> G in <math>N(m/kg)^2</math>.
  * @result {number}
  * @returns {{call :Object, decode: function}}
  */
@@ -709,10 +813,10 @@ module.exports.getWarpFactor = function getWarpFactor() {
  * @description The time warp rate, using regular "on-rails" time warp. A value between
  * 0 and 7 inclusive. 0 means no time warp. Returns 0 if physical time warp
  * is active.
- *
+ * 
  * If requested time warp factor cannot be set, it will be set to the next
  * lowest possible value. For example, if the vessel is too close to a
- * planet. See <a href="http://wiki.kerbalspaceprogram.com/wiki/Time_warp">
+ * planet. See <a href="https://wiki.kerbalspaceprogram.com/wiki/Time_warp">
  * the KSP wiki</a> for details.
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -730,10 +834,10 @@ module.exports.getRailsWarpFactor = function getRailsWarpFactor() {
  * @description The time warp rate, using regular "on-rails" time warp. A value between
  * 0 and 7 inclusive. 0 means no time warp. Returns 0 if physical time warp
  * is active.
- *
+ * 
  * If requested time warp factor cannot be set, it will be set to the next
  * lowest possible value. For example, if the vessel is too close to a
- * planet. See <a href="http://wiki.kerbalspaceprogram.com/wiki/Time_warp">
+ * planet. See <a href="https://wiki.kerbalspaceprogram.com/wiki/Time_warp">
  * the KSP wiki</a> for details.
  * @param {number} value
  * @result {void}
@@ -786,7 +890,8 @@ module.exports.setPhysicsWarpFactor = function setPhysicsWarpFactor(value) {
  * @augments SpaceCenter
  * @description The current maximum regular "on-rails" warp factor that can be set.
  * A value between 0 and 7 inclusive. See
- * <a href="http://wiki.kerbalspaceprogram.com/wiki/Time_warp">the KSP wiki</a> for details.
+ * <a href="https://wiki.kerbalspaceprogram.com/wiki/Time_warp">the KSP wiki</a>
+ * for details.
  * @result {number}
  * @returns {{call :Object, decode: function}}
  */
@@ -800,7 +905,7 @@ module.exports.getMaximumRailsWarpFactor = function getMaximumRailsWarpFactor() 
 
 /**
  * @augments SpaceCenter
- * @description Whether <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/19321-105-ferram-aerospace-research-v01557-johnson-21816/">Ferram Aerospace Research</a> is installed.
+ * @description Whether <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/19321-130-ferram-aerospace-research-v0159-liebe-82117/">Ferram Aerospace Research</a> is installed.
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
  */
@@ -848,7 +953,8 @@ module.exports.autoPilotDisengage = function autoPilotDisengage(autoPilot) {
 
 /**
  * @augments SpaceCenter
- * @description Blocks until the vessel is pointing in the target direction and has the target roll (if set).
+ * @description Blocks until the vessel is pointing in the target direction and has
+ * the target roll (if set). Throws an exception if the auto-pilot has not been engaged.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @result {void}
  * @returns {void}
@@ -887,7 +993,7 @@ module.exports.autoPilotTargetPitchAndHeading = function autoPilotTargetPitchAnd
 /**
  * @augments SpaceCenter
  * @description The error, in degrees, between the direction the ship has been asked
- * to point in and the direction it is pointing in. Returns zero if the auto-pilot
+ * to point in and the direction it is pointing in. Throws an exception if the auto-pilot
  * has not been engaged and SAS is not enabled or is in stability assist mode.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @result {number}
@@ -906,7 +1012,7 @@ module.exports.autoPilotGetError = function autoPilotGetError(autoPilot) {
 /**
  * @augments SpaceCenter
  * @description The error, in degrees, between the vessels current and target pitch.
- * Returns zero if the auto-pilot has not been engaged.
+ * Throws an exception if the auto-pilot has not been engaged.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -924,7 +1030,7 @@ module.exports.autoPilotGetPitchError = function autoPilotGetPitchError(autoPilo
 /**
  * @augments SpaceCenter
  * @description The error, in degrees, between the vessels current and target heading.
- * Returns zero if the auto-pilot has not been engaged.
+ * Throws an exception if the auto-pilot has not been engaged.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -942,7 +1048,7 @@ module.exports.autoPilotGetHeadingError = function autoPilotGetHeadingError(auto
 /**
  * @augments SpaceCenter
  * @description The error, in degrees, between the vessels current and target roll.
- * Returns zero if the auto-pilot has not been engaged or no target roll is set.
+ * Throws an exception if the auto-pilot has not been engaged or no target roll is set.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -960,8 +1066,9 @@ module.exports.autoPilotGetRollError = function autoPilotGetRollError(autoPilot)
 /**
  * @augments SpaceCenter
  * @description The reference frame for the target direction ({@link M:SpaceCenter.AutoPilot.TargetDirection}).
- *  An error will be thrown if this property is set to a reference frame that rotates with the vessel being controlled,
- * as it is impossible to rotate the vessel in such a reference frame.
+ *  An error will be thrown if this property is set to a reference frame that rotates with
+ * the vessel being controlled, as it is impossible to rotate the vessel in such a
+ * reference frame.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @result {Long} A long value representing the id for the SpaceCenter.ReferenceFrame
  * @returns {{call :Object, decode: function}}
@@ -979,8 +1086,9 @@ module.exports.autoPilotGetReferenceFrame = function autoPilotGetReferenceFrame(
 /**
  * @augments SpaceCenter
  * @description The reference frame for the target direction ({@link M:SpaceCenter.AutoPilot.TargetDirection}).
- *  An error will be thrown if this property is set to a reference frame that rotates with the vessel being controlled,
- * as it is impossible to rotate the vessel in such a reference frame.
+ *  An error will be thrown if this property is set to a reference frame that rotates with
+ * the vessel being controlled, as it is impossible to rotate the vessel in such a
+ * reference frame.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @param {Long} value - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {void}
@@ -1071,7 +1179,7 @@ module.exports.autoPilotSetTargetHeading = function autoPilotSetTargetHeading(au
 
 /**
  * @augments SpaceCenter
- * @description The target roll, in degrees. <c>NaN</c> if no target roll is set.
+ * @description The target roll, in degrees. NaN if no target roll is set.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -1088,7 +1196,7 @@ module.exports.autoPilotGetTargetRoll = function autoPilotGetTargetRoll(autoPilo
 
 /**
  * @augments SpaceCenter
- * @description The target roll, in degrees. <c>NaN</c> if no target roll is set.
+ * @description The target roll, in degrees. NaN if no target roll is set.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @param {number} value
  * @result {void}
@@ -1108,6 +1216,7 @@ module.exports.autoPilotSetTargetRoll = function autoPilotSetTargetRoll(autoPilo
 /**
  * @augments SpaceCenter
  * @description Direction vector corresponding to the target pitch and heading.
+ * This is in the reference frame specified by {@link T:SpaceCenter.ReferenceFrame}.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -1133,6 +1242,7 @@ module.exports.autoPilotGetTargetDirection = function autoPilotGetTargetDirectio
 /**
  * @augments SpaceCenter
  * @description Direction vector corresponding to the target pitch and heading.
+ * This is in the reference frame specified by {@link T:SpaceCenter.ReferenceFrame}.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @param {{number, number, number}} value
  * @result {void}
@@ -1190,7 +1300,8 @@ module.exports.autoPilotSetSas = function autoPilotSetSas(autoPilot, value) {
 /**
  * @augments SpaceCenter
  * @description The current {@link T:SpaceCenter.SASMode}.
- * These modes are equivalent to the mode buttons to the left of the navball that appear when SAS is enabled.
+ * These modes are equivalent to the mode buttons to the left of the navball that appear
+ * when SAS is enabled.
  * <remarks>Equivalent to {@link M:SpaceCenter.Control.SASMode}
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @result {Long} A long value representing the id for the SpaceCenter.SASMode
@@ -1220,7 +1331,8 @@ module.exports.autoPilotGetSasMode = function autoPilotGetSasMode(autoPilot) {
 /**
  * @augments SpaceCenter
  * @description The current {@link T:SpaceCenter.SASMode}.
- * These modes are equivalent to the mode buttons to the left of the navball that appear when SAS is enabled.
+ * These modes are equivalent to the mode buttons to the left of the navball that appear
+ * when SAS is enabled.
  * <remarks>Equivalent to {@link M:SpaceCenter.Control.SASMode}
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @param {Long} value - A long value representing the id for the SpaceCenter.SASMode
@@ -1291,8 +1403,8 @@ module.exports.autoPilotSetRollThreshold = function autoPilotSetRollThreshold(au
  * @augments SpaceCenter
  * @description The maximum amount of time that the vessel should need to come to a complete stop.
  * This determines the maximum angular velocity of the vessel.
- * A vector of three stopping times, in seconds, one for each of the pitch, roll and yaw axes.
- * Defaults to 0.5 seconds for each axis.
+ * A vector of three stopping times, in seconds, one for each of the pitch, roll
+ * and yaw axes. Defaults to 0.5 seconds for each axis.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -1319,8 +1431,8 @@ module.exports.autoPilotGetStoppingTime = function autoPilotGetStoppingTime(auto
  * @augments SpaceCenter
  * @description The maximum amount of time that the vessel should need to come to a complete stop.
  * This determines the maximum angular velocity of the vessel.
- * A vector of three stopping times, in seconds, one for each of the pitch, roll and yaw axes.
- * Defaults to 0.5 seconds for each axis.
+ * A vector of three stopping times, in seconds, one for each of the pitch, roll
+ * and yaw axes. Defaults to 0.5 seconds for each axis.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @param {{number, number, number}} value
  * @result {void}
@@ -1389,7 +1501,8 @@ module.exports.autoPilotSetDecelerationTime = function autoPilotSetDecelerationT
 
 /**
  * @augments SpaceCenter
- * @description The angle at which the autopilot considers the vessel to be pointing close to the target.
+ * @description The angle at which the autopilot considers the vessel to be pointing
+ * close to the target.
  * This determines the midpoint of the target velocity attenuation function.
  * A vector of three angles, in degrees, one for each of the pitch, roll and yaw axes.
  * Defaults to 1° for each axis.
@@ -1417,7 +1530,8 @@ module.exports.autoPilotGetAttenuationAngle = function autoPilotGetAttenuationAn
 
 /**
  * @augments SpaceCenter
- * @description The angle at which the autopilot considers the vessel to be pointing close to the target.
+ * @description The angle at which the autopilot considers the vessel to be pointing
+ * close to the target.
  * This determines the midpoint of the target velocity attenuation function.
  * A vector of three angles, in degrees, one for each of the pitch, roll and yaw axes.
  * Defaults to 1° for each axis.
@@ -1439,8 +1553,8 @@ module.exports.autoPilotSetAttenuationAngle = function autoPilotSetAttenuationAn
 
 /**
  * @augments SpaceCenter
- * @description Whether the rotation rate controllers PID parameters should be automatically tuned using the
- * vessels moment of inertia and available torque. Defaults to <c>true</c>.
+ * @description Whether the rotation rate controllers PID parameters should be automatically tuned
+ * using the vessels moment of inertia and available torque. Defaults to true.
  * See {@link M:SpaceCenter.AutoPilot.TimeToPeak} and {@link M:SpaceCenter.AutoPilot.Overshoot}.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @result {boolean}
@@ -1458,8 +1572,8 @@ module.exports.autoPilotGetAutoTune = function autoPilotGetAutoTune(autoPilot) {
 
 /**
  * @augments SpaceCenter
- * @description Whether the rotation rate controllers PID parameters should be automatically tuned using the
- * vessels moment of inertia and available torque. Defaults to <c>true</c>.
+ * @description Whether the rotation rate controllers PID parameters should be automatically tuned
+ * using the vessels moment of inertia and available torque. Defaults to true.
  * See {@link M:SpaceCenter.AutoPilot.TimeToPeak} and {@link M:SpaceCenter.AutoPilot.Overshoot}.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @param {boolean} value
@@ -1576,7 +1690,8 @@ module.exports.autoPilotSetOvershoot = function autoPilotSetOvershoot(autoPilot,
 /**
  * @augments SpaceCenter
  * @description Gains for the pitch PID controller.
- *  When {@link M:SpaceCenter.AutoPilot.AutoTune} is true, these values are updated automatically, which will overwrite any manual changes.
+ *  When {@link M:SpaceCenter.AutoPilot.AutoTune} is true, these values are updated automatically,
+ * which will overwrite any manual changes.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -1602,7 +1717,8 @@ module.exports.autoPilotGetPitchPidGains = function autoPilotGetPitchPidGains(au
 /**
  * @augments SpaceCenter
  * @description Gains for the pitch PID controller.
- *  When {@link M:SpaceCenter.AutoPilot.AutoTune} is true, these values are updated automatically, which will overwrite any manual changes.
+ *  When {@link M:SpaceCenter.AutoPilot.AutoTune} is true, these values are updated automatically,
+ * which will overwrite any manual changes.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @param {{number, number, number}} value
  * @result {void}
@@ -1622,7 +1738,8 @@ module.exports.autoPilotSetPitchPidGains = function autoPilotSetPitchPidGains(au
 /**
  * @augments SpaceCenter
  * @description Gains for the roll PID controller.
- *  When {@link M:SpaceCenter.AutoPilot.AutoTune} is true, these values are updated automatically, which will overwrite any manual changes.
+ *  When {@link M:SpaceCenter.AutoPilot.AutoTune} is true, these values are updated automatically,
+ * which will overwrite any manual changes.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -1648,7 +1765,8 @@ module.exports.autoPilotGetRollPidGains = function autoPilotGetRollPidGains(auto
 /**
  * @augments SpaceCenter
  * @description Gains for the roll PID controller.
- *  When {@link M:SpaceCenter.AutoPilot.AutoTune} is true, these values are updated automatically, which will overwrite any manual changes.
+ *  When {@link M:SpaceCenter.AutoPilot.AutoTune} is true, these values are updated automatically,
+ * which will overwrite any manual changes.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @param {{number, number, number}} value
  * @result {void}
@@ -1668,7 +1786,8 @@ module.exports.autoPilotSetRollPidGains = function autoPilotSetRollPidGains(auto
 /**
  * @augments SpaceCenter
  * @description Gains for the yaw PID controller.
- *  When {@link M:SpaceCenter.AutoPilot.AutoTune} is true, these values are updated automatically, which will overwrite any manual changes.
+ *  When {@link M:SpaceCenter.AutoPilot.AutoTune} is true, these values are updated automatically,
+ * which will overwrite any manual changes.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -1694,7 +1813,8 @@ module.exports.autoPilotGetYawPidGains = function autoPilotGetYawPidGains(autoPi
 /**
  * @augments SpaceCenter
  * @description Gains for the yaw PID controller.
- *  When {@link M:SpaceCenter.AutoPilot.AutoTune} is true, these values are updated automatically, which will overwrite any manual changes.
+ *  When {@link M:SpaceCenter.AutoPilot.AutoTune} is true, these values are updated automatically,
+ * which will overwrite any manual changes.
  * @param {Long} autoPilot - A long value representing the id for the SpaceCenter.AutoPilot
  * @param {{number, number, number}} value
  * @result {void}
@@ -1963,7 +2083,7 @@ module.exports.cameraGetDefaultDistance = function cameraGetDefaultDistance(came
 /**
  * @augments SpaceCenter
  * @description In map mode, the celestial body that the camera is focussed on.
- * Returns <c>null</c> if the camera is not focussed on a celestial body.
+ * Returns null if the camera is not focussed on a celestial body.
  * Returns an error is the camera is not in map mode.
  * @param {Long} camera - A long value representing the id for the SpaceCenter.Camera
  * @result {Long} A long value representing the id for the SpaceCenter.CelestialBody
@@ -1982,7 +2102,7 @@ module.exports.cameraGetFocussedBody = function cameraGetFocussedBody(camera) {
 /**
  * @augments SpaceCenter
  * @description In map mode, the celestial body that the camera is focussed on.
- * Returns <c>null</c> if the camera is not focussed on a celestial body.
+ * Returns null if the camera is not focussed on a celestial body.
  * Returns an error is the camera is not in map mode.
  * @param {Long} camera - A long value representing the id for the SpaceCenter.Camera
  * @param {Long} value - A long value representing the id for the SpaceCenter.CelestialBody
@@ -2003,7 +2123,7 @@ module.exports.cameraSetFocussedBody = function cameraSetFocussedBody(camera, va
 /**
  * @augments SpaceCenter
  * @description In map mode, the vessel that the camera is focussed on.
- * Returns <c>null</c> if the camera is not focussed on a vessel.
+ * Returns null if the camera is not focussed on a vessel.
  * Returns an error is the camera is not in map mode.
  * @param {Long} camera - A long value representing the id for the SpaceCenter.Camera
  * @result {Long} A long value representing the id for the SpaceCenter.Vessel
@@ -2022,7 +2142,7 @@ module.exports.cameraGetFocussedVessel = function cameraGetFocussedVessel(camera
 /**
  * @augments SpaceCenter
  * @description In map mode, the vessel that the camera is focussed on.
- * Returns <c>null</c> if the camera is not focussed on a vessel.
+ * Returns null if the camera is not focussed on a vessel.
  * Returns an error is the camera is not in map mode.
  * @param {Long} camera - A long value representing the id for the SpaceCenter.Camera
  * @param {Long} value - A long value representing the id for the SpaceCenter.Vessel
@@ -2043,7 +2163,7 @@ module.exports.cameraSetFocussedVessel = function cameraSetFocussedVessel(camera
 /**
  * @augments SpaceCenter
  * @description In map mode, the maneuver node that the camera is focussed on.
- * Returns <c>null</c> if the camera is not focussed on a maneuver node.
+ * Returns null if the camera is not focussed on a maneuver node.
  * Returns an error is the camera is not in map mode.
  * @param {Long} camera - A long value representing the id for the SpaceCenter.Camera
  * @result {Long} A long value representing the id for the SpaceCenter.Node
@@ -2062,7 +2182,7 @@ module.exports.cameraGetFocussedNode = function cameraGetFocussedNode(camera) {
 /**
  * @augments SpaceCenter
  * @description In map mode, the maneuver node that the camera is focussed on.
- * Returns <c>null</c> if the camera is not focussed on a maneuver node.
+ * Returns null if the camera is not focussed on a maneuver node.
  * Returns an error is the camera is not in map mode.
  * @param {Long} camera - A long value representing the id for the SpaceCenter.Camera
  * @param {Long} value - A long value representing the id for the SpaceCenter.Node
@@ -2082,11 +2202,11 @@ module.exports.cameraSetFocussedNode = function cameraSetFocussedNode(camera, va
 
 /**
  * @augments SpaceCenter
- * @description The height of the surface relative to mean sea level at the given position,
- * in meters. When over water this is equal to 0.
+ * @description The height of the surface relative to mean sea level, in meters,
+ * at the given position. When over water this is equal to 0.
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
- * @param {number} latitude - Latitude in degrees
- * @param {number} longitude - Longitude in degrees
+ * @param {number} latitude - Latitude in degrees.
+ * @param {number} longitude - Longitude in degrees.
  * @result {number}
  * @returns {{call :Object, decode: function}}
  */
@@ -2104,12 +2224,12 @@ module.exports.celestialBodySurfaceHeight = function celestialBodySurfaceHeight(
 
 /**
  * @augments SpaceCenter
- * @description The height of the surface relative to mean sea level at the given position,
- * in meters. When over water, this is the height of the sea-bed and is therefore a
- * negative value.
+ * @description The height of the surface relative to mean sea level, in meters,
+ * at the given position. When over water, this is the height
+ * of the sea-bed and is therefore  negative value.
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
- * @param {number} latitude - Latitude in degrees
- * @param {number} longitude - Longitude in degrees
+ * @param {number} latitude - Latitude in degrees.
+ * @param {number} longitude - Longitude in degrees.
  * @result {number}
  * @returns {{call :Object, decode: function}}
  */
@@ -2127,10 +2247,12 @@ module.exports.celestialBodyBedrockHeight = function celestialBodyBedrockHeight(
 
 /**
  * @augments SpaceCenter
- * @description The position at mean sea level at the given latitude and longitude, in the given reference frame.
+ * @description The position at mean sea level at the given latitude and longitude,
+ * in the given reference frame.
+ * Returns: Position as a vector.
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
- * @param {number} latitude - Latitude in degrees
- * @param {number} longitude - Longitude in degrees
+ * @param {number} latitude - Latitude in degrees.
+ * @param {number} longitude - Longitude in degrees.
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -2160,9 +2282,10 @@ module.exports.celestialBodyMslPosition = function celestialBodyMslPosition(cele
  * @augments SpaceCenter
  * @description The position of the surface at the given latitude and longitude, in the given
  * reference frame. When over water, this is the position of the surface of the water.
+ * Returns: Position as a vector.
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
- * @param {number} latitude - Latitude in degrees
- * @param {number} longitude - Longitude in degrees
+ * @param {number} latitude - Latitude in degrees.
+ * @param {number} longitude - Longitude in degrees.
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -2192,9 +2315,10 @@ module.exports.celestialBodySurfacePosition = function celestialBodySurfacePosit
  * @augments SpaceCenter
  * @description The position of the surface at the given latitude and longitude, in the given
  * reference frame. When over water, this is the position at the bottom of the sea-bed.
+ * Returns: Position as a vector.
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
- * @param {number} latitude - Latitude in degrees
- * @param {number} longitude - Longitude in degrees
+ * @param {number} latitude - Latitude in degrees.
+ * @param {number} longitude - Longitude in degrees.
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -2222,7 +2346,196 @@ module.exports.celestialBodyBedrockPosition = function celestialBodyBedrockPosit
 
 /**
  * @augments SpaceCenter
- * @description The biomes at the given latitude and longitude, in degrees.
+ * @description The position at the given latitude, longitude and altitude, in the given reference frame.
+ * Returns: Position as a vector.
+ * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
+ * @param {number} latitude - Latitude in degrees.
+ * @param {number} longitude - Longitude in degrees.
+ * @param {number} altitude - Altitude in meters above sea level.
+ * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
+ * @result {{number, number, number}}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.celestialBodyPositionAtAltitude = function celestialBodyPositionAtAltitude(celestialBody, latitude, longitude, altitude, referenceFrame) {
+    let encodedArguments = [
+        encoders.uInt64(celestialBody),
+        encoders.double(latitude),
+        encoders.double(longitude),
+        encoders.double(altitude),
+        encoders.uInt64(referenceFrame)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CelestialBody_PositionAtAltitude', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.Tuple,
+            subTypes: [
+                decoders.double,
+                decoders.double,
+                decoders.double
+            ]
+        }
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The latitude of the given position, in the given reference frame.
+ * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
+ * @param {{number, number, number}} position - Position as a vector.
+ * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.celestialBodyLatitudeAtPosition = function celestialBodyLatitudeAtPosition(celestialBody, position, referenceFrame) {
+    let encodedArguments = [
+        encoders.uInt64(celestialBody),
+        {buffer: proto.Tuple.encode(position).finish()},
+        encoders.uInt64(referenceFrame)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CelestialBody_LatitudeAtPosition', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The longitude of the given position, in the given reference frame.
+ * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
+ * @param {{number, number, number}} position - Position as a vector.
+ * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.celestialBodyLongitudeAtPosition = function celestialBodyLongitudeAtPosition(celestialBody, position, referenceFrame) {
+    let encodedArguments = [
+        encoders.uInt64(celestialBody),
+        {buffer: proto.Tuple.encode(position).finish()},
+        encoders.uInt64(referenceFrame)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CelestialBody_LongitudeAtPosition', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The altitude, in meters, of the given position in the given reference frame.
+ * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
+ * @param {{number, number, number}} position - Position as a vector.
+ * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.celestialBodyAltitudeAtPosition = function celestialBodyAltitudeAtPosition(celestialBody, position, referenceFrame) {
+    let encodedArguments = [
+        encoders.uInt64(celestialBody),
+        {buffer: proto.Tuple.encode(position).finish()},
+        encoders.uInt64(referenceFrame)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CelestialBody_AltitudeAtPosition', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The atmospheric density at the given position, in <math>kg/m^3</math>,
+ * in the given reference frame.
+ * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
+ * @param {{number, number, number}} position - The position vector at which to measure the density.
+ * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.celestialBodyAtmosphericDensityAtPosition = function celestialBodyAtmosphericDensityAtPosition(celestialBody, position, referenceFrame) {
+    let encodedArguments = [
+        encoders.uInt64(celestialBody),
+        {buffer: proto.Tuple.encode(position).finish()},
+        encoders.uInt64(referenceFrame)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CelestialBody_AtmosphericDensityAtPosition', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The temperature on the body at the given position, in the given reference frame.
+ * 
+ * 
+ *  This calculation is performed using the bodies current position, which means that
+ * the value could be wrong if you want to know the temperature in the far future.
+ * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
+ * @param {{number, number, number}} position - Position as a vector.
+ * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.celestialBodyTemperatureAt = function celestialBodyTemperatureAt(celestialBody, position, referenceFrame) {
+    let encodedArguments = [
+        encoders.uInt64(celestialBody),
+        {buffer: proto.Tuple.encode(position).finish()},
+        encoders.uInt64(referenceFrame)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CelestialBody_TemperatureAt', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Gets the air density, in <math>kg/m^3</math>, for the specified
+ * altitude above sea level, in meters.
+ *  This is an approximation, because actual calculations, taking sun exposure into account
+ * to compute air temperature, require us to know the exact point on the body where the
+ * density is to be computed (knowing the altitude is not enough).
+ * However, the difference is small for high altitudes, so it makes very little difference
+ * for trajectory prediction.
+ * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
+ * @param {number} altitude
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.celestialBodyDensityAt = function celestialBodyDensityAt(celestialBody, altitude) {
+    let encodedArguments = [
+        encoders.uInt64(celestialBody),
+        encoders.double(altitude)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CelestialBody_DensityAt', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Gets the air pressure, in Pascals, for the specified
+ * altitude above sea level, in meters.
+ * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
+ * @param {number} altitude
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.celestialBodyPressureAt = function celestialBodyPressureAt(celestialBody, altitude) {
+    let encodedArguments = [
+        encoders.uInt64(celestialBody),
+        encoders.double(altitude)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CelestialBody_PressureAt', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The biome at the given latitude and longitude, in degrees.
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
  * @param {number} latitude
  * @param {number} longitude
@@ -2243,7 +2556,10 @@ module.exports.celestialBodyBiomeAt = function celestialBodyBiomeAt(celestialBod
 
 /**
  * @augments SpaceCenter
- * @description Returns the position vector of the center of the body in the specified reference frame.
+ * @description The position of the center of the body, in the specified reference frame.
+ * Returns: The position as a vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * position vector is in.</param>
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -2270,7 +2586,11 @@ module.exports.celestialBodyPosition = function celestialBodyPosition(celestialB
 
 /**
  * @augments SpaceCenter
- * @description Returns the velocity vector of the body in the specified reference frame.
+ * @description The linear velocity of the body, in the specified reference frame.
+ * Returns: The velocity as a vector. The vector points in the direction of travel,
+ * and its magnitude is the speed of the body in meters per second.
+ * <param name="referenceFrame">The reference frame that the returned
+ * velocity vector is in.</param>
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -2297,7 +2617,10 @@ module.exports.celestialBodyVelocity = function celestialBodyVelocity(celestialB
 
 /**
  * @augments SpaceCenter
- * @description Returns the rotation of the body in the specified reference frame.
+ * @description The rotation of the body, in the specified reference frame.
+ * Returns: The rotation as a quaternion of the form <math>(x, y, z, w)</math>.
+ * <param name="referenceFrame">The reference frame that the returned
+ * rotation is in.</param>
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number, number}}
@@ -2325,8 +2648,11 @@ module.exports.celestialBodyRotation = function celestialBodyRotation(celestialB
 
 /**
  * @augments SpaceCenter
- * @description Returns the direction in which the north pole of the celestial body is
- * pointing, as a unit vector, in the specified reference frame.
+ * @description The direction in which the north pole of the celestial body is pointing,
+ * in the specified reference frame.
+ * Returns: The direction as a unit vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * direction is in.</param>
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -2353,10 +2679,12 @@ module.exports.celestialBodyDirection = function celestialBodyDirection(celestia
 
 /**
  * @augments SpaceCenter
- * @description Returns the angular velocity of the body in the specified reference
- * frame. The magnitude of the vector is the rotational speed of the body, in
- * radians per second, and the direction of the vector indicates the axis of
- * rotation, using the right-hand rule.
+ * @description The angular velocity of the body in the specified reference frame.
+ * Returns: The angular velocity as a vector. The magnitude of the vector is the rotational
+ * speed of the body, in radians per second. The direction of the vector indicates the axis
+ * of rotation, using the right-hand rule.
+ * <param name="referenceFrame">The reference frame the returned
+ * angular velocity is in.</param>
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -2458,7 +2786,8 @@ module.exports.celestialBodyGetGravitationalParameter = function celestialBodyGe
 
 /**
  * @augments SpaceCenter
- * @description The acceleration due to gravity at sea level (mean altitude) on the body, in <math>m/s^2</math>.
+ * @description The acceleration due to gravity at sea level (mean altitude) on the body,
+ * in <math>m/s^2</math>.
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -2510,6 +2839,7 @@ module.exports.celestialBodyGetRotationalSpeed = function celestialBodyGetRotati
 /**
  * @augments SpaceCenter
  * @description The current rotation angle of the body, in radians.
+ * A value between 0 and <math>2\pi</math>
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -2527,6 +2857,7 @@ module.exports.celestialBodyGetRotationAngle = function celestialBodyGetRotation
 /**
  * @augments SpaceCenter
  * @description The initial rotation angle of the body (at UT 0), in radians.
+ * A value between 0 and <math>2\pi</math>
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -2594,7 +2925,7 @@ module.exports.celestialBodyGetOrbit = function celestialBodyGetOrbit(celestialB
 
 /**
  * @augments SpaceCenter
- * @description <summary><c>true</c> if the body has an atmosphere.
+ * @description <summary>true if the body has an atmosphere.
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
@@ -2628,7 +2959,7 @@ module.exports.celestialBodyGetAtmosphereDepth = function celestialBodyGetAtmosp
 
 /**
  * @augments SpaceCenter
- * @description <summary><c>true</c> if there is oxygen in the atmosphere, required for air-breathing engines.
+ * @description <summary>true if there is oxygen in the atmosphere, required for air-breathing engines.
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
@@ -2668,7 +2999,8 @@ module.exports.celestialBodyGetBiomes = function celestialBodyGetBiomes(celestia
 
 /**
  * @augments SpaceCenter
- * @description The altitude, in meters, above which a vessel is considered to be flying "high" when doing science.
+ * @description The altitude, in meters, above which a vessel is considered to be
+ * flying "high" when doing science.
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -2685,7 +3017,8 @@ module.exports.celestialBodyGetFlyingHighAltitudeThreshold = function celestialB
 
 /**
  * @augments SpaceCenter
- * @description The altitude, in meters, above which a vessel is considered to be in "high" space when doing science.
+ * @description The altitude, in meters, above which a vessel is considered to be
+ * in "high" space when doing science.
  * @param {Long} celestialBody - A long value representing the id for the SpaceCenter.CelestialBody
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -2747,7 +3080,7 @@ module.exports.celestialBodyGetNonRotatingReferenceFrame = function celestialBod
 
 /**
  * @augments SpaceCenter
- * @description Gets the reference frame that is fixed relative to this celestial body, but
+ * @description The reference frame that is fixed relative to this celestial body, but
  * orientated with the body's orbital prograde/normal/radial directions.
  * <list type="bullet"><item><description>The origin is at the center of the body.
  * </description></item><item><description>The axes rotate with the orbital prograde/normal/radial
@@ -2771,8 +3104,1038 @@ module.exports.celestialBodyGetOrbitalReferenceFrame = function celestialBodyGet
 
 /**
  * @augments SpaceCenter
+ * @description The type of link.
+ * @param {Long} commLink - A long value representing the id for the SpaceCenter.CommLink
+ * @result {Long} A long value representing the id for the SpaceCenter.CommLinkType
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.commLinkGetType = function commLinkGetType(commLink) {
+    let encodedArguments = [
+        encoders.uInt64(commLink)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CommLink_get_Type', encodedArguments),
+        decode: decoders.enum({
+            0: 'Home',
+            1: 'Control',
+            2: 'Relay'
+        })
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Signal strength of the link.
+ * @param {Long} commLink - A long value representing the id for the SpaceCenter.CommLink
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.commLinkGetSignalStrength = function commLinkGetSignalStrength(commLink) {
+    let encodedArguments = [
+        encoders.uInt64(commLink)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CommLink_get_SignalStrength', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Start point of the link.
+ * @param {Long} commLink - A long value representing the id for the SpaceCenter.CommLink
+ * @result {Long} A long value representing the id for the SpaceCenter.CommNode
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.commLinkGetStart = function commLinkGetStart(commLink) {
+    let encodedArguments = [
+        encoders.uInt64(commLink)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CommLink_get_Start', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Start point of the link.
+ * @param {Long} commLink - A long value representing the id for the SpaceCenter.CommLink
+ * @result {Long} A long value representing the id for the SpaceCenter.CommNode
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.commLinkGetEnd = function commLinkGetEnd(commLink) {
+    let encodedArguments = [
+        encoders.uInt64(commLink)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CommLink_get_End', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Name of the communication node.
+ * @param {Long} commNode - A long value representing the id for the SpaceCenter.CommNode
+ * @result {string}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.commNodeGetName = function commNodeGetName(commNode) {
+    let encodedArguments = [
+        encoders.uInt64(commNode)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CommNode_get_Name', encodedArguments),
+        decode: decoders.string
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the communication node is on Kerbin.
+ * @param {Long} commNode - A long value representing the id for the SpaceCenter.CommNode
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.commNodeGetIsHome = function commNodeGetIsHome(commNode) {
+    let encodedArguments = [
+        encoders.uInt64(commNode)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CommNode_get_IsHome', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the communication node is a control point, for example a manned vessel.
+ * @param {Long} commNode - A long value representing the id for the SpaceCenter.CommNode
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.commNodeGetIsControlPoint = function commNodeGetIsControlPoint(commNode) {
+    let encodedArguments = [
+        encoders.uInt64(commNode)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CommNode_get_IsControlPoint', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the communication node is a vessel.
+ * @param {Long} commNode - A long value representing the id for the SpaceCenter.CommNode
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.commNodeGetIsVessel = function commNodeGetIsVessel(commNode) {
+    let encodedArguments = [
+        encoders.uInt64(commNode)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CommNode_get_IsVessel', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The vessel for this communication node.
+ * @param {Long} commNode - A long value representing the id for the SpaceCenter.CommNode
+ * @result {Long} A long value representing the id for the SpaceCenter.Vessel
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.commNodeGetVessel = function commNodeGetVessel(commNode) {
+    let encodedArguments = [
+        encoders.uInt64(commNode)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CommNode_get_Vessel', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the vessel can communicate with KSC.
+ * @param {Long} comms - A long value representing the id for the SpaceCenter.Comms
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.commsGetCanCommunicate = function commsGetCanCommunicate(comms) {
+    let encodedArguments = [
+        encoders.uInt64(comms)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Comms_get_CanCommunicate', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the vessel can transmit science data to KSC.
+ * @param {Long} comms - A long value representing the id for the SpaceCenter.Comms
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.commsGetCanTransmitScience = function commsGetCanTransmitScience(comms) {
+    let encodedArguments = [
+        encoders.uInt64(comms)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Comms_get_CanTransmitScience', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Signal strength to KSC.
+ * @param {Long} comms - A long value representing the id for the SpaceCenter.Comms
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.commsGetSignalStrength = function commsGetSignalStrength(comms) {
+    let encodedArguments = [
+        encoders.uInt64(comms)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Comms_get_SignalStrength', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Signal delay to KSC in seconds.
+ * @param {Long} comms - A long value representing the id for the SpaceCenter.Comms
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.commsGetSignalDelay = function commsGetSignalDelay(comms) {
+    let encodedArguments = [
+        encoders.uInt64(comms)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Comms_get_SignalDelay', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The combined power of all active antennae on the vessel.
+ * @param {Long} comms - A long value representing the id for the SpaceCenter.Comms
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.commsGetPower = function commsGetPower(comms) {
+    let encodedArguments = [
+        encoders.uInt64(comms)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Comms_get_Power', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The communication path used to control the vessel.
+ * @param {Long} comms - A long value representing the id for the SpaceCenter.Comms
+ * @result {Long[]} A list of long values representing the ids for the SpaceCenter.CommLink
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.commsGetControlPath = function commsGetControlPath(comms) {
+    let encodedArguments = [
+        encoders.uInt64(comms)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Comms_get_ControlPath', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.List,
+            subTypes: [
+                decoders.uInt64
+            ]
+        }
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Cancel an active contract.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.contractCancel = function contractCancel(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_Cancel', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Accept an offered contract.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.contractAccept = function contractAccept(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_Accept', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Decline an offered contract.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.contractDecline = function contractDecline(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_Decline', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Type of the contract.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {string}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetType = function contractGetType(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_Type', encodedArguments),
+        decode: decoders.string
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Title of the contract.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {string}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetTitle = function contractGetTitle(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_Title', encodedArguments),
+        decode: decoders.string
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Description of the contract.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {string}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetDescription = function contractGetDescription(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_Description', encodedArguments),
+        decode: decoders.string
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Notes for the contract.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {string}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetNotes = function contractGetNotes(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_Notes', encodedArguments),
+        decode: decoders.string
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Synopsis for the contract.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {string}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetSynopsis = function contractGetSynopsis(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_Synopsis', encodedArguments),
+        decode: decoders.string
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Keywords for the contract.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {string[]}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetKeywords = function contractGetKeywords(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_Keywords', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.List,
+            subTypes: [
+                decoders.string
+            ]
+        }
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description State of the contract.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {Long} A long value representing the id for the SpaceCenter.ContractState
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetState = function contractGetState(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_State', encodedArguments),
+        decode: decoders.enum({
+            0: 'Active',
+            1: 'Canceled',
+            2: 'Completed',
+            3: 'DeadlineExpired',
+            4: 'Declined',
+            5: 'Failed',
+            6: 'Generated',
+            7: 'Offered',
+            8: 'OfferExpired',
+            9: 'Withdrawn'
+        })
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the contract is active.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetActive = function contractGetActive(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_Active', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the contract has been failed.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetFailed = function contractGetFailed(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_Failed', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the contract has been seen.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetSeen = function contractGetSeen(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_Seen', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the contract has been read.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetRead = function contractGetRead(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_Read', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the contract can be canceled.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetCanBeCanceled = function contractGetCanBeCanceled(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_CanBeCanceled', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the contract can be declined.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetCanBeDeclined = function contractGetCanBeDeclined(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_CanBeDeclined', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the contract can be failed.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetCanBeFailed = function contractGetCanBeFailed(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_CanBeFailed', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Funds received when accepting the contract.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetFundsAdvance = function contractGetFundsAdvance(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_FundsAdvance', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Funds received on completion of the contract.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetFundsCompletion = function contractGetFundsCompletion(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_FundsCompletion', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Funds lost if the contract is failed.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetFundsFailure = function contractGetFundsFailure(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_FundsFailure', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Reputation gained on completion of the contract.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetReputationCompletion = function contractGetReputationCompletion(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_ReputationCompletion', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Reputation lost if the contract is failed.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetReputationFailure = function contractGetReputationFailure(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_ReputationFailure', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Science gained on completion of the contract.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetScienceCompletion = function contractGetScienceCompletion(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_ScienceCompletion', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Parameters for the contract.
+ * @param {Long} contract - A long value representing the id for the SpaceCenter.Contract
+ * @result {Long[]} A list of long values representing the ids for the SpaceCenter.ContractParameter
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractGetParameters = function contractGetParameters(contract) {
+    let encodedArguments = [
+        encoders.uInt64(contract)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Contract_get_Parameters', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.List,
+            subTypes: [
+                decoders.uInt64
+            ]
+        }
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description A list of all contract types.
+ * @param {Long} contractManager - A long value representing the id for the SpaceCenter.ContractManager
+ * @result {string[]}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractManagerGetTypes = function contractManagerGetTypes(contractManager) {
+    let encodedArguments = [
+        encoders.uInt64(contractManager)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractManager_get_Types', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.Set,
+            subTypes: [
+                decoders.string
+            ]
+        }
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description A list of all contracts.
+ * @param {Long} contractManager - A long value representing the id for the SpaceCenter.ContractManager
+ * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Contract
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractManagerGetAllContracts = function contractManagerGetAllContracts(contractManager) {
+    let encodedArguments = [
+        encoders.uInt64(contractManager)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractManager_get_AllContracts', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.List,
+            subTypes: [
+                decoders.uInt64
+            ]
+        }
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description A list of all active contracts.
+ * @param {Long} contractManager - A long value representing the id for the SpaceCenter.ContractManager
+ * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Contract
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractManagerGetActiveContracts = function contractManagerGetActiveContracts(contractManager) {
+    let encodedArguments = [
+        encoders.uInt64(contractManager)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractManager_get_ActiveContracts', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.List,
+            subTypes: [
+                decoders.uInt64
+            ]
+        }
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description A list of all offered, but unaccepted, contracts.
+ * @param {Long} contractManager - A long value representing the id for the SpaceCenter.ContractManager
+ * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Contract
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractManagerGetOfferedContracts = function contractManagerGetOfferedContracts(contractManager) {
+    let encodedArguments = [
+        encoders.uInt64(contractManager)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractManager_get_OfferedContracts', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.List,
+            subTypes: [
+                decoders.uInt64
+            ]
+        }
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description A list of all completed contracts.
+ * @param {Long} contractManager - A long value representing the id for the SpaceCenter.ContractManager
+ * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Contract
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractManagerGetCompletedContracts = function contractManagerGetCompletedContracts(contractManager) {
+    let encodedArguments = [
+        encoders.uInt64(contractManager)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractManager_get_CompletedContracts', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.List,
+            subTypes: [
+                decoders.uInt64
+            ]
+        }
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description A list of all failed contracts.
+ * @param {Long} contractManager - A long value representing the id for the SpaceCenter.ContractManager
+ * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Contract
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractManagerGetFailedContracts = function contractManagerGetFailedContracts(contractManager) {
+    let encodedArguments = [
+        encoders.uInt64(contractManager)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractManager_get_FailedContracts', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.List,
+            subTypes: [
+                decoders.uInt64
+            ]
+        }
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Title of the parameter.
+ * @param {Long} contractParameter - A long value representing the id for the SpaceCenter.ContractParameter
+ * @result {string}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractParameterGetTitle = function contractParameterGetTitle(contractParameter) {
+    let encodedArguments = [
+        encoders.uInt64(contractParameter)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractParameter_get_Title', encodedArguments),
+        decode: decoders.string
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Notes for the parameter.
+ * @param {Long} contractParameter - A long value representing the id for the SpaceCenter.ContractParameter
+ * @result {string}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractParameterGetNotes = function contractParameterGetNotes(contractParameter) {
+    let encodedArguments = [
+        encoders.uInt64(contractParameter)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractParameter_get_Notes', encodedArguments),
+        decode: decoders.string
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Child contract parameters.
+ * @param {Long} contractParameter - A long value representing the id for the SpaceCenter.ContractParameter
+ * @result {Long[]} A list of long values representing the ids for the SpaceCenter.ContractParameter
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractParameterGetChildren = function contractParameterGetChildren(contractParameter) {
+    let encodedArguments = [
+        encoders.uInt64(contractParameter)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractParameter_get_Children', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.List,
+            subTypes: [
+                decoders.uInt64
+            ]
+        }
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the parameter has been completed.
+ * @param {Long} contractParameter - A long value representing the id for the SpaceCenter.ContractParameter
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractParameterGetCompleted = function contractParameterGetCompleted(contractParameter) {
+    let encodedArguments = [
+        encoders.uInt64(contractParameter)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractParameter_get_Completed', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the parameter has been failed.
+ * @param {Long} contractParameter - A long value representing the id for the SpaceCenter.ContractParameter
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractParameterGetFailed = function contractParameterGetFailed(contractParameter) {
+    let encodedArguments = [
+        encoders.uInt64(contractParameter)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractParameter_get_Failed', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the contract parameter is optional.
+ * @param {Long} contractParameter - A long value representing the id for the SpaceCenter.ContractParameter
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractParameterGetOptional = function contractParameterGetOptional(contractParameter) {
+    let encodedArguments = [
+        encoders.uInt64(contractParameter)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractParameter_get_Optional', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Funds received on completion of the contract parameter.
+ * @param {Long} contractParameter - A long value representing the id for the SpaceCenter.ContractParameter
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractParameterGetFundsCompletion = function contractParameterGetFundsCompletion(contractParameter) {
+    let encodedArguments = [
+        encoders.uInt64(contractParameter)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractParameter_get_FundsCompletion', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Funds lost if the contract parameter is failed.
+ * @param {Long} contractParameter - A long value representing the id for the SpaceCenter.ContractParameter
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractParameterGetFundsFailure = function contractParameterGetFundsFailure(contractParameter) {
+    let encodedArguments = [
+        encoders.uInt64(contractParameter)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractParameter_get_FundsFailure', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Reputation gained on completion of the contract parameter.
+ * @param {Long} contractParameter - A long value representing the id for the SpaceCenter.ContractParameter
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractParameterGetReputationCompletion = function contractParameterGetReputationCompletion(contractParameter) {
+    let encodedArguments = [
+        encoders.uInt64(contractParameter)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractParameter_get_ReputationCompletion', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Reputation lost if the contract parameter is failed.
+ * @param {Long} contractParameter - A long value representing the id for the SpaceCenter.ContractParameter
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractParameterGetReputationFailure = function contractParameterGetReputationFailure(contractParameter) {
+    let encodedArguments = [
+        encoders.uInt64(contractParameter)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractParameter_get_ReputationFailure', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Science gained on completion of the contract parameter.
+ * @param {Long} contractParameter - A long value representing the id for the SpaceCenter.ContractParameter
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.contractParameterGetScienceCompletion = function contractParameterGetScienceCompletion(contractParameter) {
+    let encodedArguments = [
+        encoders.uInt64(contractParameter)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ContractParameter_get_ScienceCompletion', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
  * @description Activates the next stage. Equivalent to pressing the space bar in-game.
- * <returns>A list of vessel objects that are jettisoned from the active vessel.</returns>
+ * Returns: A list of vessel objects that are jettisoned from the active vessel.
+ *  When called, the active vessel may change. It is therefore possible that,
+ * after calling this function, the object(s) returned by previous call(s) to
+ * {@link M:SpaceCenter.ActiveVessel} no longer refer to the active vessel.
  * @param {Long} control - A long value representing the id for the SpaceCenter.Control
  * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Vessel
  * @returns {{call :Object, decode: function}}
@@ -2795,15 +4158,15 @@ module.exports.controlActivateNextStage = function controlActivateNextStage(cont
 
 /**
  * @augments SpaceCenter
- * @description Returns <c>true</c> if the given action group is enabled.
+ * @description Returns true if the given action group is enabled.
  * <param name="group">
  * A number between 0 and 9 inclusive,
- * or between 0 and 250 inclusive when the <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/67235-12oct3116-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech">Extended Action Groups mod</a> is installed.
+ * or between 0 and 250 inclusive when the <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/67235-122dec1016-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech/">Extended Action Groups mod</a> is installed.
  * </param>
  * @param {Long} control - A long value representing the id for the SpaceCenter.Control
- * @param {number} group -
- A number between 0 and 9 inclusive,
- or between 0 and 250 inclusive when the <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/67235-12oct3116-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech,Extended Action Groups mod</a> is installed.
+ * @param {number} group - 
+A number between 0 and 9 inclusive,
+or between 0 and 250 inclusive when the <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/67235-122dec1016-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech/,Extended Action Groups mod</a> is installed.
 
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
@@ -2824,12 +4187,12 @@ module.exports.controlGetActionGroup = function controlGetActionGroup(control, g
  * @description Sets the state of the given action group.
  * <param name="group">
  * A number between 0 and 9 inclusive,
- * or between 0 and 250 inclusive when the <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/67235-12oct3116-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech">Extended Action Groups mod</a> is installed.
+ * or between 0 and 250 inclusive when the <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/67235-122dec1016-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech/">Extended Action Groups mod</a> is installed.
  * </param>
  * @param {Long} control - A long value representing the id for the SpaceCenter.Control
- * @param {number} group -
- A number between 0 and 9 inclusive,
- or between 0 and 250 inclusive when the <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/67235-12oct3116-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech,Extended Action Groups mod</a> is installed.
+ * @param {number} group - 
+A number between 0 and 9 inclusive,
+or between 0 and 250 inclusive when the <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/67235-122dec1016-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech/,Extended Action Groups mod</a> is installed.
 
  * @param {boolean} state
  * @result {void}
@@ -2852,12 +4215,12 @@ module.exports.controlSetActionGroup = function controlSetActionGroup(control, g
  * @description Toggles the state of the given action group.
  * <param name="group">
  * A number between 0 and 9 inclusive,
- * or between 0 and 250 inclusive when the <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/67235-12oct3116-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech">Extended Action Groups mod</a> is installed.
+ * or between 0 and 250 inclusive when the <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/67235-122dec1016-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech/">Extended Action Groups mod</a> is installed.
  * </param>
  * @param {Long} control - A long value representing the id for the SpaceCenter.Control
- * @param {number} group -
- A number between 0 and 9 inclusive,
- or between 0 and 250 inclusive when the <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/67235-12oct3116-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech,Extended Action Groups mod</a> is installed.
+ * @param {number} group - 
+A number between 0 and 9 inclusive,
+or between 0 and 250 inclusive when the <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/67235-122dec1016-action-groups-extended-250-action-groups-in-flight-editing-now-kosremotetech/,Extended Action Groups mod</a> is installed.
 
  * @result {void}
  * @returns {void}
@@ -2915,6 +4278,48 @@ module.exports.controlRemoveNodes = function controlRemoveNodes(control) {
     return {
         call: buildProcedureCall('SpaceCenter', 'Control_RemoveNodes', encodedArguments),
         decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The control state of the vessel.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @result {Long} A long value representing the id for the SpaceCenter.ControlState
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.controlGetState = function controlGetState(control) {
+    let encodedArguments = [
+        encoders.uInt64(control)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_get_State', encodedArguments),
+        decode: decoders.enum({
+            0: 'Full',
+            1: 'Partial',
+            2: 'None'
+        })
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The source of the vessels control, for example by a kerbal or a probe core.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @result {Long} A long value representing the id for the SpaceCenter.ControlSource
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.controlGetSource = function controlGetSource(control) {
+    let encodedArguments = [
+        encoders.uInt64(control)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_get_Source', encodedArguments),
+        decode: decoders.enum({
+            0: 'Kerbal',
+            1: 'Probe',
+            2: 'None'
+        })
     };
 };
 
@@ -3104,6 +4509,46 @@ module.exports.controlSetRcs = function controlSetRcs(control, value) {
 
 /**
  * @augments SpaceCenter
+ * @description Returns whether all reactive wheels on the vessel are active,
+ * and sets the active state of all reaction wheels.
+ * See {@link M:SpaceCenter.ReactionWheel.Active}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.controlGetReactionWheels = function controlGetReactionWheels(control) {
+    let encodedArguments = [
+        encoders.uInt64(control)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_get_ReactionWheels', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether all reactive wheels on the vessel are active,
+ * and sets the active state of all reaction wheels.
+ * See {@link M:SpaceCenter.ReactionWheel.Active}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.controlSetReactionWheels = function controlSetReactionWheels(control, value) {
+    let encodedArguments = [
+        encoders.uInt64(control),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_set_ReactionWheels', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
  * @description The state of the landing gear/legs.
  * @param {Long} control - A long value representing the id for the SpaceCenter.Control
  * @result {boolean}
@@ -3134,6 +4579,90 @@ module.exports.controlSetGear = function controlSetGear(control, value) {
     ];
     return {
         call: buildProcedureCall('SpaceCenter', 'Control_set_Gear', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether all landing legs on the vessel are deployed,
+ * and sets the deployment state of all landing legs.
+ * Does not include wheels (for example landing gear).
+ * See {@link M:SpaceCenter.Leg.Deployed}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.controlGetLegs = function controlGetLegs(control) {
+    let encodedArguments = [
+        encoders.uInt64(control)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_get_Legs', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether all landing legs on the vessel are deployed,
+ * and sets the deployment state of all landing legs.
+ * Does not include wheels (for example landing gear).
+ * See {@link M:SpaceCenter.Leg.Deployed}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.controlSetLegs = function controlSetLegs(control, value) {
+    let encodedArguments = [
+        encoders.uInt64(control),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_set_Legs', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether all wheels on the vessel are deployed,
+ * and sets the deployment state of all wheels.
+ * Does not include landing legs.
+ * See {@link M:SpaceCenter.Wheel.Deployed}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.controlGetWheels = function controlGetWheels(control) {
+    let encodedArguments = [
+        encoders.uInt64(control)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_get_Wheels', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether all wheels on the vessel are deployed,
+ * and sets the deployment state of all wheels.
+ * Does not include landing legs.
+ * See {@link M:SpaceCenter.Wheel.Deployed}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.controlSetWheels = function controlSetWheels(control, value) {
+    let encodedArguments = [
+        encoders.uInt64(control),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_set_Wheels', encodedArguments),
         decode: null
     };
 };
@@ -3212,6 +4741,328 @@ module.exports.controlSetBrakes = function controlSetBrakes(control, value) {
 
 /**
  * @augments SpaceCenter
+ * @description Returns whether all antennas on the vessel are deployed,
+ * and sets the deployment state of all antennas.
+ * See {@link M:SpaceCenter.Antenna.Deployed}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.controlGetAntennas = function controlGetAntennas(control) {
+    let encodedArguments = [
+        encoders.uInt64(control)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_get_Antennas', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether all antennas on the vessel are deployed,
+ * and sets the deployment state of all antennas.
+ * See {@link M:SpaceCenter.Antenna.Deployed}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.controlSetAntennas = function controlSetAntennas(control, value) {
+    let encodedArguments = [
+        encoders.uInt64(control),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_set_Antennas', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether any of the cargo bays on the vessel are open,
+ * and sets the open state of all cargo bays.
+ * See {@link M:SpaceCenter.CargoBay.Open}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.controlGetCargoBays = function controlGetCargoBays(control) {
+    let encodedArguments = [
+        encoders.uInt64(control)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_get_CargoBays', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether any of the cargo bays on the vessel are open,
+ * and sets the open state of all cargo bays.
+ * See {@link M:SpaceCenter.CargoBay.Open}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.controlSetCargoBays = function controlSetCargoBays(control, value) {
+    let encodedArguments = [
+        encoders.uInt64(control),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_set_CargoBays', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether all of the air intakes on the vessel are open,
+ * and sets the open state of all air intakes.
+ * See {@link M:SpaceCenter.Intake.Open}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.controlGetIntakes = function controlGetIntakes(control) {
+    let encodedArguments = [
+        encoders.uInt64(control)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_get_Intakes', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether all of the air intakes on the vessel are open,
+ * and sets the open state of all air intakes.
+ * See {@link M:SpaceCenter.Intake.Open}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.controlSetIntakes = function controlSetIntakes(control, value) {
+    let encodedArguments = [
+        encoders.uInt64(control),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_set_Intakes', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether all parachutes on the vessel are deployed,
+ * and sets the deployment state of all parachutes.
+ * Cannot be set to false.
+ * See {@link M:SpaceCenter.Parachute.Deployed}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.controlGetParachutes = function controlGetParachutes(control) {
+    let encodedArguments = [
+        encoders.uInt64(control)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_get_Parachutes', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether all parachutes on the vessel are deployed,
+ * and sets the deployment state of all parachutes.
+ * Cannot be set to false.
+ * See {@link M:SpaceCenter.Parachute.Deployed}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.controlSetParachutes = function controlSetParachutes(control, value) {
+    let encodedArguments = [
+        encoders.uInt64(control),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_set_Parachutes', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether all radiators on the vessel are deployed,
+ * and sets the deployment state of all radiators.
+ * See {@link M:SpaceCenter.Radiator.Deployed}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.controlGetRadiators = function controlGetRadiators(control) {
+    let encodedArguments = [
+        encoders.uInt64(control)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_get_Radiators', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether all radiators on the vessel are deployed,
+ * and sets the deployment state of all radiators.
+ * See {@link M:SpaceCenter.Radiator.Deployed}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.controlSetRadiators = function controlSetRadiators(control, value) {
+    let encodedArguments = [
+        encoders.uInt64(control),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_set_Radiators', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether all of the resource harvesters on the vessel are deployed,
+ * and sets the deployment state of all resource harvesters.
+ * See {@link M:SpaceCenter.ResourceHarvester.Deployed}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.controlGetResourceHarvesters = function controlGetResourceHarvesters(control) {
+    let encodedArguments = [
+        encoders.uInt64(control)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_get_ResourceHarvesters', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether all of the resource harvesters on the vessel are deployed,
+ * and sets the deployment state of all resource harvesters.
+ * See {@link M:SpaceCenter.ResourceHarvester.Deployed}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.controlSetResourceHarvesters = function controlSetResourceHarvesters(control, value) {
+    let encodedArguments = [
+        encoders.uInt64(control),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_set_ResourceHarvesters', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether any of the resource harvesters on the vessel are active,
+ * and sets the active state of all resource harvesters.
+ * See {@link M:SpaceCenter.ResourceHarvester.Active}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.controlGetResourceHarvestersActive = function controlGetResourceHarvestersActive(control) {
+    let encodedArguments = [
+        encoders.uInt64(control)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_get_ResourceHarvestersActive', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether any of the resource harvesters on the vessel are active,
+ * and sets the active state of all resource harvesters.
+ * See {@link M:SpaceCenter.ResourceHarvester.Active}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.controlSetResourceHarvestersActive = function controlSetResourceHarvestersActive(control, value) {
+    let encodedArguments = [
+        encoders.uInt64(control),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_set_ResourceHarvestersActive', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether all solar panels on the vessel are deployed,
+ * and sets the deployment state of all solar panels.
+ * See {@link M:SpaceCenter.SolarPanel.Deployed}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.controlGetSolarPanels = function controlGetSolarPanels(control) {
+    let encodedArguments = [
+        encoders.uInt64(control)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_get_SolarPanels', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether all solar panels on the vessel are deployed,
+ * and sets the deployment state of all solar panels.
+ * See {@link M:SpaceCenter.SolarPanel.Deployed}.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.controlSetSolarPanels = function controlSetSolarPanels(control, value) {
+    let encodedArguments = [
+        encoders.uInt64(control),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_set_SolarPanels', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
  * @description The state of the abort action group.
  * @param {Long} control - A long value representing the id for the SpaceCenter.Control
  * @result {boolean}
@@ -3278,6 +5129,58 @@ module.exports.controlSetThrottle = function controlSetThrottle(control, value) 
     ];
     return {
         call: buildProcedureCall('SpaceCenter', 'Control_set_Throttle', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Sets the behavior of the pitch, yaw, roll and translation control inputs.
+ * When set to additive, these inputs are added to the vessels current inputs.
+ * This mode is the default.
+ * When set to override, these inputs (if non-zero) override the vessels inputs.
+ * This mode prevents keyboard control, or SAS, from interfering with the controls when
+ * they are set.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @result {Long} A long value representing the id for the SpaceCenter.ControlInputMode
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.controlGetInputMode = function controlGetInputMode(control) {
+    let encodedArguments = [
+        encoders.uInt64(control)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_get_InputMode', encodedArguments),
+        decode: decoders.enum({
+            0: 'Additive',
+            1: 'Override'
+        })
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Sets the behavior of the pitch, yaw, roll and translation control inputs.
+ * When set to additive, these inputs are added to the vessels current inputs.
+ * This mode is the default.
+ * When set to override, these inputs (if non-zero) override the vessels inputs.
+ * This mode prevents keyboard control, or SAS, from interfering with the controls when
+ * they are set.
+ * @param {Long} control - A long value representing the id for the SpaceCenter.Control
+ * @param {Long} value - A long value representing the id for the SpaceCenter.ControlInputMode
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.controlSetInputMode = function controlSetInputMode(control, value) {
+    let encodedArguments = [
+        encoders.uInt64(control),
+        encoders.enum({
+            0: 'Additive',
+            1: 'Override'
+        })(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Control_set_InputMode', encodedArguments),
         decode: null
     };
 };
@@ -3647,6 +5550,296 @@ module.exports.controlGetNodes = function controlGetNodes(control) {
 
 /**
  * @augments SpaceCenter
+ * @description The crew members name.
+ * @param {Long} crewMember - A long value representing the id for the SpaceCenter.CrewMember
+ * @result {string}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.crewMemberGetName = function crewMemberGetName(crewMember) {
+    let encodedArguments = [
+        encoders.uInt64(crewMember)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CrewMember_get_Name', encodedArguments),
+        decode: decoders.string
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The crew members name.
+ * @param {Long} crewMember - A long value representing the id for the SpaceCenter.CrewMember
+ * @param {string} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.crewMemberSetName = function crewMemberSetName(crewMember, value) {
+    let encodedArguments = [
+        encoders.uInt64(crewMember),
+        encoders.string(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CrewMember_set_Name', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The type of crew member.
+ * @param {Long} crewMember - A long value representing the id for the SpaceCenter.CrewMember
+ * @result {Long} A long value representing the id for the SpaceCenter.CrewMemberType
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.crewMemberGetType = function crewMemberGetType(crewMember) {
+    let encodedArguments = [
+        encoders.uInt64(crewMember)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CrewMember_get_Type', encodedArguments),
+        decode: decoders.enum({
+            0: 'Applicant',
+            1: 'Crew',
+            2: 'Tourist',
+            3: 'Unowned'
+        })
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the crew member is on a mission.
+ * @param {Long} crewMember - A long value representing the id for the SpaceCenter.CrewMember
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.crewMemberGetOnMission = function crewMemberGetOnMission(crewMember) {
+    let encodedArguments = [
+        encoders.uInt64(crewMember)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CrewMember_get_OnMission', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The crew members courage.
+ * @param {Long} crewMember - A long value representing the id for the SpaceCenter.CrewMember
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.crewMemberGetCourage = function crewMemberGetCourage(crewMember) {
+    let encodedArguments = [
+        encoders.uInt64(crewMember)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CrewMember_get_Courage', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The crew members courage.
+ * @param {Long} crewMember - A long value representing the id for the SpaceCenter.CrewMember
+ * @param {number} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.crewMemberSetCourage = function crewMemberSetCourage(crewMember, value) {
+    let encodedArguments = [
+        encoders.uInt64(crewMember),
+        encoders.float(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CrewMember_set_Courage', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The crew members stupidity.
+ * @param {Long} crewMember - A long value representing the id for the SpaceCenter.CrewMember
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.crewMemberGetStupidity = function crewMemberGetStupidity(crewMember) {
+    let encodedArguments = [
+        encoders.uInt64(crewMember)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CrewMember_get_Stupidity', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The crew members stupidity.
+ * @param {Long} crewMember - A long value representing the id for the SpaceCenter.CrewMember
+ * @param {number} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.crewMemberSetStupidity = function crewMemberSetStupidity(crewMember, value) {
+    let encodedArguments = [
+        encoders.uInt64(crewMember),
+        encoders.float(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CrewMember_set_Stupidity', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The crew members experience.
+ * @param {Long} crewMember - A long value representing the id for the SpaceCenter.CrewMember
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.crewMemberGetExperience = function crewMemberGetExperience(crewMember) {
+    let encodedArguments = [
+        encoders.uInt64(crewMember)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CrewMember_get_Experience', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The crew members experience.
+ * @param {Long} crewMember - A long value representing the id for the SpaceCenter.CrewMember
+ * @param {number} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.crewMemberSetExperience = function crewMemberSetExperience(crewMember, value) {
+    let encodedArguments = [
+        encoders.uInt64(crewMember),
+        encoders.float(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CrewMember_set_Experience', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the crew member is a badass.
+ * @param {Long} crewMember - A long value representing the id for the SpaceCenter.CrewMember
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.crewMemberGetBadass = function crewMemberGetBadass(crewMember) {
+    let encodedArguments = [
+        encoders.uInt64(crewMember)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CrewMember_get_Badass', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the crew member is a badass.
+ * @param {Long} crewMember - A long value representing the id for the SpaceCenter.CrewMember
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.crewMemberSetBadass = function crewMemberSetBadass(crewMember, value) {
+    let encodedArguments = [
+        encoders.uInt64(crewMember),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CrewMember_set_Badass', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the crew member is a veteran.
+ * @param {Long} crewMember - A long value representing the id for the SpaceCenter.CrewMember
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.crewMemberGetVeteran = function crewMemberGetVeteran(crewMember) {
+    let encodedArguments = [
+        encoders.uInt64(crewMember)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CrewMember_get_Veteran', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the crew member is a veteran.
+ * @param {Long} crewMember - A long value representing the id for the SpaceCenter.CrewMember
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.crewMemberSetVeteran = function crewMemberSetVeteran(crewMember, value) {
+    let encodedArguments = [
+        encoders.uInt64(crewMember),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'CrewMember_set_Veteran', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Simulate and return the total aerodynamic forces acting on the vessel,
+ * if it where to be traveling with the given velocity at the given position in the
+ * atmosphere of the given celestial body.
+ * Returns: A vector pointing in the direction that the force acts,
+ * with its magnitude equal to the strength of the force in Newtons.
+ * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
+ * @param {Long} body - A long value representing the id for the SpaceCenter.CelestialBody
+ * @param {{number, number, number}} position
+ * @param {{number, number, number}} velocity
+ * @result {{number, number, number}}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.flightSimulateAerodynamicForceAt = function flightSimulateAerodynamicForceAt(flight, body, position, velocity) {
+    let encodedArguments = [
+        encoders.uInt64(flight),
+        encoders.uInt64(body),
+        {buffer: proto.Tuple.encode(position).finish()},
+        {buffer: proto.Tuple.encode(velocity).finish()}
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Flight_SimulateAerodynamicForceAt', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.Tuple,
+            subTypes: [
+                decoders.double,
+                decoders.double,
+                decoders.double
+            ]
+        }
+    };
+};
+
+/**
+ * @augments SpaceCenter
  * @description The current G force acting on the vessel in <math>m/s^2</math>.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
@@ -3770,8 +5963,9 @@ module.exports.flightGetLongitude = function flightGetLongitude(flight) {
 
 /**
  * @augments SpaceCenter
- * @description The velocity vector of the vessel. The magnitude of the vector is the speed of the vessel in meters per second.
- * The direction of the vector is the direction of the vessels motion.
+ * @description The velocity of the vessel, in the reference frame {@link T:SpaceCenter.ReferenceFrame}.
+ * Returns: The velocity as a vector. The vector points in the direction of travel,
+ * and its magnitude is the speed of the vessel in meters per second.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -3796,7 +5990,8 @@ module.exports.flightGetVelocity = function flightGetVelocity(flight) {
 
 /**
  * @augments SpaceCenter
- * @description The speed of the vessel in meters per second.
+ * @description The speed of the vessel in meters per second,
+ * in the reference frame {@link T:SpaceCenter.ReferenceFrame}.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -3813,7 +6008,8 @@ module.exports.flightGetSpeed = function flightGetSpeed(flight) {
 
 /**
  * @augments SpaceCenter
- * @description The horizontal speed of the vessel in meters per second.
+ * @description The horizontal speed of the vessel in meters per second,
+ * in the reference frame {@link T:SpaceCenter.ReferenceFrame}.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -3830,7 +6026,8 @@ module.exports.flightGetHorizontalSpeed = function flightGetHorizontalSpeed(flig
 
 /**
  * @augments SpaceCenter
- * @description The vertical speed of the vessel in meters per second.
+ * @description The vertical speed of the vessel in meters per second,
+ * in the reference frame {@link T:SpaceCenter.ReferenceFrame}.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -3847,7 +6044,8 @@ module.exports.flightGetVerticalSpeed = function flightGetVerticalSpeed(flight) 
 
 /**
  * @augments SpaceCenter
- * @description The position of the center of mass of the vessel.
+ * @description The position of the center of mass of the vessel,
+ * in the reference frame {@link T:SpaceCenter.ReferenceFrame}<returns>The position as a vector.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -3872,7 +6070,7 @@ module.exports.flightGetCenterOfMass = function flightGetCenterOfMass(flight) {
 
 /**
  * @augments SpaceCenter
- * @description The rotation of the vessel.
+ * @description The rotation of the vessel, in the reference frame {@link T:SpaceCenter.ReferenceFrame}<returns>The rotation as a quaternion of the form <math>(x, y, z, w)</math>.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {{number, number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -3898,7 +6096,9 @@ module.exports.flightGetRotation = function flightGetRotation(flight) {
 
 /**
  * @augments SpaceCenter
- * @description The direction vector that the vessel is pointing in.
+ * @description The direction that the vessel is pointing in,
+ * in the reference frame {@link T:SpaceCenter.ReferenceFrame}.
+ * Returns: The direction as a unit vector.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -3923,7 +6123,8 @@ module.exports.flightGetDirection = function flightGetDirection(flight) {
 
 /**
  * @augments SpaceCenter
- * @description The pitch angle of the vessel relative to the horizon, in degrees. A value between -90° and +90°.
+ * @description The pitch of the vessel relative to the horizon, in degrees.
+ * A value between -90° and +90°.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -3940,7 +6141,8 @@ module.exports.flightGetPitch = function flightGetPitch(flight) {
 
 /**
  * @augments SpaceCenter
- * @description The heading angle of the vessel relative to north, in degrees. A value between 0° and 360°.
+ * @description The heading of the vessel (its angle relative to north), in degrees.
+ * A value between 0° and 360°.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -3957,7 +6159,8 @@ module.exports.flightGetHeading = function flightGetHeading(flight) {
 
 /**
  * @augments SpaceCenter
- * @description The roll angle of the vessel relative to the horizon, in degrees. A value between -180° and +180°.
+ * @description The roll of the vessel relative to the horizon, in degrees.
+ * A value between -180° and +180°.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -3974,7 +6177,9 @@ module.exports.flightGetRoll = function flightGetRoll(flight) {
 
 /**
  * @augments SpaceCenter
- * @description The unit direction vector pointing in the prograde direction.
+ * @description The prograde direction of the vessels orbit,
+ * in the reference frame {@link T:SpaceCenter.ReferenceFrame}.
+ * Returns: The direction as a unit vector.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -3999,7 +6204,9 @@ module.exports.flightGetPrograde = function flightGetPrograde(flight) {
 
 /**
  * @augments SpaceCenter
- * @description The unit direction vector pointing in the retrograde direction.
+ * @description The retrograde direction of the vessels orbit,
+ * in the reference frame {@link T:SpaceCenter.ReferenceFrame}.
+ * Returns: The direction as a unit vector.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -4024,7 +6231,9 @@ module.exports.flightGetRetrograde = function flightGetRetrograde(flight) {
 
 /**
  * @augments SpaceCenter
- * @description The unit direction vector pointing in the normal direction.
+ * @description The direction normal to the vessels orbit,
+ * in the reference frame {@link T:SpaceCenter.ReferenceFrame}.
+ * Returns: The direction as a unit vector.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -4049,7 +6258,9 @@ module.exports.flightGetNormal = function flightGetNormal(flight) {
 
 /**
  * @augments SpaceCenter
- * @description The unit direction vector pointing in the anti-normal direction.
+ * @description The direction opposite to the normal of the vessels orbit,
+ * in the reference frame {@link T:SpaceCenter.ReferenceFrame}.
+ * Returns: The direction as a unit vector.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -4074,7 +6285,9 @@ module.exports.flightGetAntiNormal = function flightGetAntiNormal(flight) {
 
 /**
  * @augments SpaceCenter
- * @description The unit direction vector pointing in the radial direction.
+ * @description The radial direction of the vessels orbit,
+ * in the reference frame {@link T:SpaceCenter.ReferenceFrame}.
+ * Returns: The direction as a unit vector.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -4099,7 +6312,9 @@ module.exports.flightGetRadial = function flightGetRadial(flight) {
 
 /**
  * @augments SpaceCenter
- * @description The unit direction vector pointing in the anti-radial direction.
+ * @description The direction opposite to the radial direction of the vessels orbit,
+ * in the reference frame {@link T:SpaceCenter.ReferenceFrame}.
+ * Returns: The direction as a unit vector.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -4141,8 +6356,9 @@ module.exports.flightGetAtmosphereDensity = function flightGetAtmosphereDensity(
 
 /**
  * @augments SpaceCenter
- * @description The dynamic pressure acting on the vessel, in Pascals. This is a measure of the strength of the
- * aerodynamic forces. It is equal to <math>\frac{1}{2} . \mbox{air density} . \mbox{velocity}^2</math>.
+ * @description The dynamic pressure acting on the vessel, in Pascals. This is a measure of the
+ * strength of the aerodynamic forces. It is equal to
+ * <math>\frac{1}{2} . \mbox{air density} . \mbox{velocity}^2</math>.
  * It is commonly denoted <math>Q</math>.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
@@ -4194,8 +6410,10 @@ module.exports.flightGetStaticPressure = function flightGetStaticPressure(flight
 
 /**
  * @augments SpaceCenter
- * @description The total aerodynamic forces acting on the vessel, as a vector pointing in the direction of the force, with its
- * magnitude equal to the strength of the force in Newtons.
+ * @description The total aerodynamic forces acting on the vessel,
+ * in reference frame {@link T:SpaceCenter.ReferenceFrame}.
+ * Returns: A vector pointing in the direction that the force acts,
+ * with its magnitude equal to the strength of the force in Newtons.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -4220,8 +6438,10 @@ module.exports.flightGetAerodynamicForce = function flightGetAerodynamicForce(fl
 
 /**
  * @augments SpaceCenter
- * @description The <a href="https://en.wikipedia.org/wiki/Aerodynamic_force">aerodynamic lift</a> currently acting on the vessel,
- * as a vector pointing in the direction of the force, with its magnitude equal to the strength of the force in Newtons.
+ * @description The <a href="https://en.wikipedia.org/wiki/Aerodynamic_force">aerodynamic lift</a>
+ * currently acting on the vessel.
+ * Returns: A vector pointing in the direction that the force acts,
+ * with its magnitude equal to the strength of the force in Newtons.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -4246,8 +6466,9 @@ module.exports.flightGetLift = function flightGetLift(flight) {
 
 /**
  * @augments SpaceCenter
- * @description The <a href="https://en.wikipedia.org/wiki/Aerodynamic_force">aerodynamic drag</a> currently acting on the vessel,
- * as a vector pointing in the direction of the force, with its magnitude equal to the strength of the force in Newtons.
+ * @description The <a href="https://en.wikipedia.org/wiki/Aerodynamic_force">aerodynamic drag</a> currently acting on the vessel.
+ * Returns: A vector pointing in the direction of the force, with its magnitude
+ * equal to the strength of the force in Newtons.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -4307,7 +6528,7 @@ module.exports.flightGetMach = function flightGetMach(flight) {
 /**
  * @augments SpaceCenter
  * @description The vessels Reynolds number.
- *  Requires <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/19321-105-ferram-aerospace-research-v01557-johnson-21816/">Ferram Aerospace Research</a>.
+ *  Requires <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/19321-130-ferram-aerospace-research-v0159-liebe-82117/">Ferram Aerospace Research</a>.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -4324,7 +6545,8 @@ module.exports.flightGetReynoldsNumber = function flightGetReynoldsNumber(flight
 
 /**
  * @augments SpaceCenter
- * @description The <a href="https://en.wikipedia.org/wiki/True_airspeed">true air speed</a> of the vessel, in <math>m/s</math>.
+ * @description The <a href="https://en.wikipedia.org/wiki/True_airspeed">true air speed</a>
+ * of the vessel, in meters per second.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -4341,7 +6563,8 @@ module.exports.flightGetTrueAirSpeed = function flightGetTrueAirSpeed(flight) {
 
 /**
  * @augments SpaceCenter
- * @description The <a href="https://en.wikipedia.org/wiki/Equivalent_airspeed">equivalent air speed</a> of the vessel, in <math>m/s</math>.
+ * @description The <a href="https://en.wikipedia.org/wiki/Equivalent_airspeed">equivalent air speed</a>
+ * of the vessel, in meters per second.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -4358,7 +6581,7 @@ module.exports.flightGetEquivalentAirSpeed = function flightGetEquivalentAirSpee
 
 /**
  * @augments SpaceCenter
- * @description An estimate of the current terminal velocity of the vessel, in <math>m/s</math>.
+ * @description An estimate of the current terminal velocity of the vessel, in meters per second.
  * This is the speed at which the drag forces cancel out the force of gravity.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
@@ -4376,7 +6599,8 @@ module.exports.flightGetTerminalVelocity = function flightGetTerminalVelocity(fl
 
 /**
  * @augments SpaceCenter
- * @description Gets the pitch angle between the orientation of the vessel and its velocity vector, in degrees.
+ * @description The pitch angle between the orientation of the vessel and its velocity vector,
+ * in degrees.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -4393,7 +6617,7 @@ module.exports.flightGetAngleOfAttack = function flightGetAngleOfAttack(flight) 
 
 /**
  * @augments SpaceCenter
- * @description Gets the yaw angle between the orientation of the vessel and its velocity vector, in degrees.
+ * @description The yaw angle between the orientation of the vessel and its velocity vector, in degrees.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -4410,8 +6634,9 @@ module.exports.flightGetSideslipAngle = function flightGetSideslipAngle(flight) 
 
 /**
  * @augments SpaceCenter
- * @description The <a href="https://en.wikipedia.org/wiki/Total_air_temperature">total air temperature</a> of the atmosphere
- * around the vessel, in Kelvin. This temperature includes the {@link M:SpaceCenter.Flight.StaticAirTemperature} and the vessel's kinetic energy.
+ * @description The <a href="https://en.wikipedia.org/wiki/Total_air_temperature">total air temperature</a>
+ * of the atmosphere around the vessel, in Kelvin.
+ * This includes the {@link M:SpaceCenter.Flight.StaticAirTemperature} and the vessel's kinetic energy.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -4428,8 +6653,8 @@ module.exports.flightGetTotalAirTemperature = function flightGetTotalAirTemperat
 
 /**
  * @augments SpaceCenter
- * @description The <a href="https://en.wikipedia.org/wiki/Total_air_temperature">static (ambient) temperature</a> of the
- * atmosphere around the vessel, in Kelvin.
+ * @description The <a href="https://en.wikipedia.org/wiki/Total_air_temperature">static (ambient)
+ * temperature</a> of the atmosphere around the vessel, in Kelvin.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -4446,9 +6671,9 @@ module.exports.flightGetStaticAirTemperature = function flightGetStaticAirTemper
 
 /**
  * @augments SpaceCenter
- * @description Gets the current amount of stall, between 0 and 1. A value greater than 0.005 indicates a minor stall
- * and a value greater than 0.5 indicates a large-scale stall.
- *  Requires <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/19321-105-ferram-aerospace-research-v01557-johnson-21816/">Ferram Aerospace Research</a>.
+ * @description The current amount of stall, between 0 and 1. A value greater than 0.005 indicates
+ * a minor stall and a value greater than 0.5 indicates a large-scale stall.
+ *  Requires <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/19321-130-ferram-aerospace-research-v0159-liebe-82117/">Ferram Aerospace Research</a>.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -4465,9 +6690,9 @@ module.exports.flightGetStallFraction = function flightGetStallFraction(flight) 
 
 /**
  * @augments SpaceCenter
- * @description Gets the coefficient of drag. This is the amount of drag produced by the vessel. It depends on air speed,
- * air density and wing area.
- *  Requires <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/19321-105-ferram-aerospace-research-v01557-johnson-21816/">Ferram Aerospace Research</a>.
+ * @description The coefficient of drag. This is the amount of drag produced by the vessel.
+ * It depends on air speed, air density and wing area.
+ *  Requires <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/19321-130-ferram-aerospace-research-v0159-liebe-82117/">Ferram Aerospace Research</a>.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -4484,8 +6709,9 @@ module.exports.flightGetDragCoefficient = function flightGetDragCoefficient(flig
 
 /**
  * @augments SpaceCenter
- * @description Gets the coefficient of lift. This is the amount of lift produced by the vessel, and depends on air speed, air density and wing area.
- *  Requires <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/19321-105-ferram-aerospace-research-v01557-johnson-21816/">Ferram Aerospace Research</a>.
+ * @description The coefficient of lift. This is the amount of lift produced by the vessel, and
+ * depends on air speed, air density and wing area.
+ *  Requires <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/19321-130-ferram-aerospace-research-v0159-liebe-82117/">Ferram Aerospace Research</a>.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -4502,8 +6728,8 @@ module.exports.flightGetLiftCoefficient = function flightGetLiftCoefficient(flig
 
 /**
  * @augments SpaceCenter
- * @description Gets the <a href="https://en.wikipedia.org/wiki/Ballistic_coefficient">ballistic coefficient</a>.
- *  Requires <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/19321-105-ferram-aerospace-research-v01557-johnson-21816/">Ferram Aerospace Research</a>.
+ * @description The <a href="https://en.wikipedia.org/wiki/Ballistic_coefficient">ballistic coefficient</a>.
+ *  Requires <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/19321-130-ferram-aerospace-research-v0159-liebe-82117/">Ferram Aerospace Research</a>.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -4520,10 +6746,11 @@ module.exports.flightGetBallisticCoefficient = function flightGetBallisticCoeffi
 
 /**
  * @augments SpaceCenter
- * @description Gets the thrust specific fuel consumption for the jet engines on the vessel. This is a measure of the
- * efficiency of the engines, with a lower value indicating a more efficient vessel. This value is the
- * number of Newtons of fuel that are burned, per hour, to produce one newton of thrust.
- *  Requires <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/19321-105-ferram-aerospace-research-v01557-johnson-21816/">Ferram Aerospace Research</a>.
+ * @description The thrust specific fuel consumption for the jet engines on the vessel. This is a
+ * measure of the efficiency of the engines, with a lower value indicating a more
+ * efficient vessel. This value is the number of Newtons of fuel that are burned,
+ * per hour, to produce one newton of thrust.
+ *  Requires <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/19321-130-ferram-aerospace-research-v0159-liebe-82117/">Ferram Aerospace Research</a>.
  * @param {Long} flight - A long value representing the id for the SpaceCenter.Flight
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -4540,9 +6767,12 @@ module.exports.flightGetThrustSpecificFuelConsumption = function flightGetThrust
 
 /**
  * @augments SpaceCenter
- * @description Returns a vector whose direction the direction of the maneuver node burn, and whose magnitude
- * is the delta-v of the burn in m/s.
- *
+ * @description Returns the burn vector for the maneuver node.
+ * <param name="referenceFrame">The reference frame that the returned vector is in.
+ * Defaults to {@link M:SpaceCenter.Vessel.OrbitalReferenceFrame}.</param>
+ * Returns: A vector whose direction is the direction of the maneuver node burn, and
+ * magnitude is the delta-v of the burn in meters per second.
+ * 
  *  Does not change when executing the maneuver node. See {@link M:SpaceCenter.Node.RemainingBurnVector}.
  * @param {Long} node - A long value representing the id for the SpaceCenter.Node
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
@@ -4570,8 +6800,13 @@ module.exports.nodeBurnVector = function nodeBurnVector(node, referenceFrame) {
 
 /**
  * @augments SpaceCenter
- * @description Returns a vector whose direction the direction of the maneuver node burn, and whose magnitude
- * is the delta-v of the burn in m/s. The direction and magnitude change as the burn is executed.
+ * @description Returns the remaining burn vector for the maneuver node.
+ * <param name="referenceFrame">The reference frame that the returned vector is in.
+ * Defaults to {@link M:SpaceCenter.Vessel.OrbitalReferenceFrame}.</param>
+ * Returns: A vector whose direction is the direction of the maneuver node burn, and
+ * magnitude is the delta-v of the burn in meters per second.
+ * 
+ *  Changes as the maneuver node is executed. See {@link M:SpaceCenter.Node.BurnVector}.
  * @param {Long} node - A long value representing the id for the SpaceCenter.Node
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -4615,7 +6850,10 @@ module.exports.nodeRemove = function nodeRemove(node) {
 
 /**
  * @augments SpaceCenter
- * @description Returns the position vector of the maneuver node in the given reference frame.
+ * @description The position vector of the maneuver node in the given reference frame.
+ * Returns: The position as a vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * position vector is in.</param>
  * @param {Long} node - A long value representing the id for the SpaceCenter.Node
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -4642,7 +6880,10 @@ module.exports.nodePosition = function nodePosition(node, referenceFrame) {
 
 /**
  * @augments SpaceCenter
- * @description Returns the unit direction vector of the maneuver nodes burn in the given reference frame.
+ * @description The direction of the maneuver nodes burn.
+ * Returns: The direction as a unit vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * direction is in.</param>
  * @param {Long} node - A long value representing the id for the SpaceCenter.Node
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -4669,7 +6910,8 @@ module.exports.nodeDirection = function nodeDirection(node, referenceFrame) {
 
 /**
  * @augments SpaceCenter
- * @description The magnitude of the maneuver nodes delta-v in the prograde direction, in meters per second.
+ * @description The magnitude of the maneuver nodes delta-v in the prograde direction,
+ * in meters per second.
  * @param {Long} node - A long value representing the id for the SpaceCenter.Node
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -4686,7 +6928,8 @@ module.exports.nodeGetPrograde = function nodeGetPrograde(node) {
 
 /**
  * @augments SpaceCenter
- * @description The magnitude of the maneuver nodes delta-v in the prograde direction, in meters per second.
+ * @description The magnitude of the maneuver nodes delta-v in the prograde direction,
+ * in meters per second.
  * @param {Long} node - A long value representing the id for the SpaceCenter.Node
  * @param {number} value
  * @result {void}
@@ -4705,7 +6948,8 @@ module.exports.nodeSetPrograde = function nodeSetPrograde(node, value) {
 
 /**
  * @augments SpaceCenter
- * @description The magnitude of the maneuver nodes delta-v in the normal direction, in meters per second.
+ * @description The magnitude of the maneuver nodes delta-v in the normal direction,
+ * in meters per second.
  * @param {Long} node - A long value representing the id for the SpaceCenter.Node
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -4722,7 +6966,8 @@ module.exports.nodeGetNormal = function nodeGetNormal(node) {
 
 /**
  * @augments SpaceCenter
- * @description The magnitude of the maneuver nodes delta-v in the normal direction, in meters per second.
+ * @description The magnitude of the maneuver nodes delta-v in the normal direction,
+ * in meters per second.
  * @param {Long} node - A long value representing the id for the SpaceCenter.Node
  * @param {number} value
  * @result {void}
@@ -4741,7 +6986,8 @@ module.exports.nodeSetNormal = function nodeSetNormal(node, value) {
 
 /**
  * @augments SpaceCenter
- * @description The magnitude of the maneuver nodes delta-v in the radial direction, in meters per second.
+ * @description The magnitude of the maneuver nodes delta-v in the radial direction,
+ * in meters per second.
  * @param {Long} node - A long value representing the id for the SpaceCenter.Node
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -4758,7 +7004,8 @@ module.exports.nodeGetRadial = function nodeGetRadial(node) {
 
 /**
  * @augments SpaceCenter
- * @description The magnitude of the maneuver nodes delta-v in the radial direction, in meters per second.
+ * @description The magnitude of the maneuver nodes delta-v in the radial direction,
+ * in meters per second.
  * @param {Long} node - A long value representing the id for the SpaceCenter.Node
  * @param {number} value
  * @result {void}
@@ -4815,8 +7062,8 @@ module.exports.nodeSetDeltaV = function nodeSetDeltaV(node, value) {
 
 /**
  * @augments SpaceCenter
- * @description Gets the remaining delta-v of the maneuver node, in meters per second. Changes as the node
- * is executed. This is equivalent to the delta-v reported in-game.
+ * @description Gets the remaining delta-v of the maneuver node, in meters per second. Changes as the
+ * node is executed. This is equivalent to the delta-v reported in-game.
  * @param {Long} node - A long value representing the id for the SpaceCenter.Node
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -4903,7 +7150,7 @@ module.exports.nodeGetOrbit = function nodeGetOrbit(node) {
 
 /**
  * @augments SpaceCenter
- * @description Gets the reference frame that is fixed relative to the maneuver node's burn.
+ * @description The reference frame that is fixed relative to the maneuver node's burn.
  * <list type="bullet"><item><description>The origin is at the position of the maneuver node.</description></item><item><description>The y-axis points in the direction of the burn.</description></item><item><description>The x-axis and z-axis point in arbitrary but fixed directions.</description></item></list>
  * @param {Long} node - A long value representing the id for the SpaceCenter.Node
  * @result {Long} A long value representing the id for the SpaceCenter.ReferenceFrame
@@ -4921,7 +7168,7 @@ module.exports.nodeGetReferenceFrame = function nodeGetReferenceFrame(node) {
 
 /**
  * @augments SpaceCenter
- * @description Gets the reference frame that is fixed relative to the maneuver node, and
+ * @description The reference frame that is fixed relative to the maneuver node, and
  * orientated with the orbital prograde/normal/radial directions of the
  * original orbit at the maneuver node's position.
  * <list type="bullet"><item><description>The origin is at the position of the maneuver node.</description></item><item><description>The x-axis points in the orbital anti-radial direction of the original
@@ -4944,8 +7191,12 @@ module.exports.nodeGetOrbitalReferenceFrame = function nodeGetOrbitalReferenceFr
 
 /**
  * @augments SpaceCenter
- * @description The unit direction vector that is normal to the orbits reference plane, in the given
- * reference frame. The reference plane is the plane from which the orbits inclination is measured.
+ * @description The direction that is normal to the orbits reference plane,
+ * in the given reference frame.
+ * The reference plane is the plane from which the orbits inclination is measured.
+ * Returns: The direction as a unit vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * direction is in.</param>
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -4970,8 +7221,11 @@ module.exports.orbitStaticReferencePlaneNormal = function orbitStaticReferencePl
 
 /**
  * @augments SpaceCenter
- * @description The unit direction vector from which the orbits longitude of ascending node is measured,
+ * @description The direction from which the orbits longitude of ascending node is measured,
  * in the given reference frame.
+ * Returns: The direction as a unit vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * direction is in.</param>
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -4991,6 +7245,25 @@ module.exports.orbitStaticReferencePlaneDirection = function orbitStaticReferenc
                 decoders.double
             ]
         }
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The mean anomaly at the given time.
+ * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
+ * @param {number} ut - The universal time in seconds.
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.orbitMeanAnomalyAtUt = function orbitMeanAnomalyAtUt(orbit, ut) {
+    let encodedArguments = [
+        encoders.uInt64(orbit),
+        encoders.double(ut)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Orbit_MeanAnomalyAtUT', encodedArguments),
+        decode: decoders.double
     };
 };
 
@@ -5110,6 +7383,191 @@ module.exports.orbitOrbitalSpeedAt = function orbitOrbitalSpeedAt(orbit, time) {
 
 /**
  * @augments SpaceCenter
+ * @description The orbital radius at the given time, in meters.
+ * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
+ * @param {number} ut - The universal time to measure the radius at.
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.orbitRadiusAt = function orbitRadiusAt(orbit, ut) {
+    let encodedArguments = [
+        encoders.uInt64(orbit),
+        encoders.double(ut)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Orbit_RadiusAt', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The position at a given time, in the specified reference frame.
+ * Returns: The position as a vector.
+ * 
+ * <param name="referenceFrame">The reference frame that the returned
+ * position vector is in.</param>
+ * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
+ * @param {number} ut - The universal time to measure the position at.
+ * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
+ * @result {{number, number, number}}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.orbitPositionAt = function orbitPositionAt(orbit, ut, referenceFrame) {
+    let encodedArguments = [
+        encoders.uInt64(orbit),
+        encoders.double(ut),
+        encoders.uInt64(referenceFrame)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Orbit_PositionAt', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.Tuple,
+            subTypes: [
+                decoders.double,
+                decoders.double,
+                decoders.double
+            ]
+        }
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Estimates and returns the time at closest approach to a target vessel.
+ * Returns: The universal time at closest approach, in seconds.
+ * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
+ * @param {Long} target - A long value representing the id for the SpaceCenter.Vessel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.orbitTimeOfClosestApproach = function orbitTimeOfClosestApproach(orbit, target) {
+    let encodedArguments = [
+        encoders.uInt64(orbit),
+        encoders.uInt64(target)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Orbit_TimeOfClosestApproach', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Estimates and returns the distance at closest approach to a target vessel, in meters.
+ * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
+ * @param {Long} target - A long value representing the id for the SpaceCenter.Vessel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.orbitDistanceAtClosestApproach = function orbitDistanceAtClosestApproach(orbit, target) {
+    let encodedArguments = [
+        encoders.uInt64(orbit),
+        encoders.uInt64(target)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Orbit_DistanceAtClosestApproach', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns the times at closest approach and corresponding distances, to a target vessel.
+ * Returns: 
+ * A list of two lists.
+ * The first is a list of times at closest approach, as universal times in seconds.
+ * The second is a list of corresponding distances at closest approach, in meters.
+ * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
+ * @param {Long} target - A long value representing the id for the SpaceCenter.Vessel
+ * @param {number} orbits - The number of future orbits to search.
+ * @result {number[][]}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.orbitListClosestApproaches = function orbitListClosestApproaches(orbit, target, orbits) {
+    let encodedArguments = [
+        encoders.uInt64(orbit),
+        encoders.uInt64(target),
+        encoders.sInt32(orbits)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Orbit_ListClosestApproaches', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.List,
+            subTypes: [
+                {
+                    isCollection: true,
+                    decode: proto.List,
+                    subTypes: [
+                        decoders.double
+                    ]
+                }
+            ]
+        }
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The true anomaly of the ascending node with the given target vessel.
+ * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
+ * @param {Long} target - A long value representing the id for the SpaceCenter.Vessel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.orbitTrueAnomalyAtAn = function orbitTrueAnomalyAtAn(orbit, target) {
+    let encodedArguments = [
+        encoders.uInt64(orbit),
+        encoders.uInt64(target)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Orbit_TrueAnomalyAtAN', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The true anomaly of the descending node with the given target vessel.
+ * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
+ * @param {Long} target - A long value representing the id for the SpaceCenter.Vessel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.orbitTrueAnomalyAtDn = function orbitTrueAnomalyAtDn(orbit, target) {
+    let encodedArguments = [
+        encoders.uInt64(orbit),
+        encoders.uInt64(target)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Orbit_TrueAnomalyAtDN', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Relative inclination of this orbit and the orbit of the given target vessel, in radians.
+ * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
+ * @param {Long} target - A long value representing the id for the SpaceCenter.Vessel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.orbitRelativeInclination = function orbitRelativeInclination(orbit, target) {
+    let encodedArguments = [
+        encoders.uInt64(orbit),
+        encoders.uInt64(target)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Orbit_RelativeInclination', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
  * @description The celestial body (e.g. planet or moon) around which the object is orbiting.
  * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
  * @result {Long} A long value representing the id for the SpaceCenter.CelestialBody
@@ -5127,8 +7585,10 @@ module.exports.orbitGetBody = function orbitGetBody(orbit) {
 
 /**
  * @augments SpaceCenter
- * @description Gets the apoapsis of the orbit, in meters, from the center of mass of the body being orbited.
- *  For the apoapsis altitude reported on the in-game map view, use {@link M:SpaceCenter.Orbit.ApoapsisAltitude}.
+ * @description Gets the apoapsis of the orbit, in meters, from the center of mass
+ * of the body being orbited.
+ *  For the apoapsis altitude reported on the in-game map view,
+ * use {@link M:SpaceCenter.Orbit.ApoapsisAltitude}.
  * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -5145,8 +7605,10 @@ module.exports.orbitGetApoapsis = function orbitGetApoapsis(orbit) {
 
 /**
  * @augments SpaceCenter
- * @description The periapsis of the orbit, in meters, from the center of mass of the body being orbited.
- *  For the periapsis altitude reported on the in-game map view, use {@link M:SpaceCenter.Orbit.PeriapsisAltitude}.
+ * @description The periapsis of the orbit, in meters, from the center of mass
+ * of the body being orbited.
+ *  For the periapsis altitude reported on the in-game map view,
+ * use {@link M:SpaceCenter.Orbit.PeriapsisAltitude}.
  * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -5234,7 +7696,8 @@ module.exports.orbitGetSemiMinorAxis = function orbitGetSemiMinorAxis(orbit) {
 /**
  * @augments SpaceCenter
  * @description The current radius of the orbit, in meters. This is the distance between the center
- * of mass of the object in orbit, and the center of mass of the body around which it is orbiting.
+ * of mass of the object in orbit, and the center of mass of the body around which it
+ * is orbiting.
  *  This value will change over time if the orbit is elliptical.
  * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
  * @result {number}
@@ -5321,7 +7784,8 @@ module.exports.orbitGetTimeToPeriapsis = function orbitGetTimeToPeriapsis(orbit)
 
 /**
  * @augments SpaceCenter
- * @description The <a href="https://en.wikipedia.org/wiki/Orbital_eccentricity">eccentricity</a> of the orbit.
+ * @description The <a href="https://en.wikipedia.org/wiki/Orbital_eccentricity">eccentricity</a>
+ * of the orbit.
  * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -5338,7 +7802,8 @@ module.exports.orbitGetEccentricity = function orbitGetEccentricity(orbit) {
 
 /**
  * @augments SpaceCenter
- * @description The <a href="https://en.wikipedia.org/wiki/Orbital_inclination">inclination</a> of the orbit,
+ * @description The <a href="https://en.wikipedia.org/wiki/Orbital_inclination">inclination</a>
+ * of the orbit,
  * in radians.
  * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
  * @result {number}
@@ -5356,8 +7821,8 @@ module.exports.orbitGetInclination = function orbitGetInclination(orbit) {
 
 /**
  * @augments SpaceCenter
- * @description The <a href="https://en.wikipedia.org/wiki/Longitude_of_the_ascending_node">longitude of the
- * ascending node</a>, in radians.
+ * @description The <a href="https://en.wikipedia.org/wiki/Longitude_of_the_ascending_node">longitude of
+ * the ascending node</a>, in radians.
  * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -5374,7 +7839,8 @@ module.exports.orbitGetLongitudeOfAscendingNode = function orbitGetLongitudeOfAs
 
 /**
  * @augments SpaceCenter
- * @description The <a href="https://en.wikipedia.org/wiki/Argument_of_periapsis">argument of periapsis</a>, in radians.
+ * @description The <a href="https://en.wikipedia.org/wiki/Argument_of_periapsis">argument of
+ * periapsis</a>, in radians.
  * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -5409,7 +7875,8 @@ module.exports.orbitGetMeanAnomalyAtEpoch = function orbitGetMeanAnomalyAtEpoch(
 /**
  * @augments SpaceCenter
  * @description The time since the epoch (the point at which the
- * <a href="https://en.wikipedia.org/wiki/Mean_anomaly">mean anomaly at epoch</a> was measured, in seconds.
+ * <a href="https://en.wikipedia.org/wiki/Mean_anomaly">mean anomaly at epoch</a>
+ * was measured, in seconds.
  * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -5477,8 +7944,8 @@ module.exports.orbitGetTrueAnomaly = function orbitGetTrueAnomaly(orbit) {
 
 /**
  * @augments SpaceCenter
- * @description If the object is going to change sphere of influence in the future, returns the new orbit
- * after the change. Otherwise returns <c>null</c>.
+ * @description If the object is going to change sphere of influence in the future, returns the new
+ * orbit after the change. Otherwise returns null.
  * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
  * @result {Long} A long value representing the id for the SpaceCenter.Orbit
  * @returns {{call :Object, decode: function}}
@@ -5495,8 +7962,8 @@ module.exports.orbitGetNextOrbit = function orbitGetNextOrbit(orbit) {
 
 /**
  * @augments SpaceCenter
- * @description The time until the object changes sphere of influence, in seconds. Returns <c>NaN</c> if the
- * object is not going to change sphere of influence.
+ * @description The time until the object changes sphere of influence, in seconds. Returns NaN
+ * if the object is not going to change sphere of influence.
  * @param {Long} orbit - A long value representing the id for the SpaceCenter.Orbit
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -5524,6 +7991,293 @@ module.exports.orbitGetOrbitalSpeed = function orbitGetOrbitalSpeed(orbit) {
     ];
     return {
         call: buildProcedureCall('SpaceCenter', 'Orbit_get_OrbitalSpeed', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Transmit data.
+ * @param {Long} antenna - A long value representing the id for the SpaceCenter.Antenna
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.antennaTransmit = function antennaTransmit(antenna) {
+    let encodedArguments = [
+        encoders.uInt64(antenna)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Antenna_Transmit', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Cancel current transmission of data.
+ * @param {Long} antenna - A long value representing the id for the SpaceCenter.Antenna
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.antennaCancel = function antennaCancel(antenna) {
+    let encodedArguments = [
+        encoders.uInt64(antenna)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Antenna_Cancel', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The part object for this antenna.
+ * @param {Long} antenna - A long value representing the id for the SpaceCenter.Antenna
+ * @result {Long} A long value representing the id for the SpaceCenter.Part
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.antennaGetPart = function antennaGetPart(antenna) {
+    let encodedArguments = [
+        encoders.uInt64(antenna)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Antenna_get_Part', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The current state of the antenna.
+ * @param {Long} antenna - A long value representing the id for the SpaceCenter.Antenna
+ * @result {Long} A long value representing the id for the SpaceCenter.AntennaState
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.antennaGetState = function antennaGetState(antenna) {
+    let encodedArguments = [
+        encoders.uInt64(antenna)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Antenna_get_State', encodedArguments),
+        decode: decoders.enum({
+            0: 'Deployed',
+            1: 'Retracted',
+            2: 'Deploying',
+            3: 'Retracting',
+            4: 'Broken'
+        })
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the antenna is deployable.
+ * @param {Long} antenna - A long value representing the id for the SpaceCenter.Antenna
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.antennaGetDeployable = function antennaGetDeployable(antenna) {
+    let encodedArguments = [
+        encoders.uInt64(antenna)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Antenna_get_Deployable', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the antenna is deployed.
+ *  Fixed antennas are always deployed.
+ * Returns an error if you try to deploy a fixed antenna.
+ * @param {Long} antenna - A long value representing the id for the SpaceCenter.Antenna
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.antennaGetDeployed = function antennaGetDeployed(antenna) {
+    let encodedArguments = [
+        encoders.uInt64(antenna)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Antenna_get_Deployed', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the antenna is deployed.
+ *  Fixed antennas are always deployed.
+ * Returns an error if you try to deploy a fixed antenna.
+ * @param {Long} antenna - A long value representing the id for the SpaceCenter.Antenna
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.antennaSetDeployed = function antennaSetDeployed(antenna, value) {
+    let encodedArguments = [
+        encoders.uInt64(antenna),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Antenna_set_Deployed', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether data can be transmitted by this antenna.
+ * @param {Long} antenna - A long value representing the id for the SpaceCenter.Antenna
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.antennaGetCanTransmit = function antennaGetCanTransmit(antenna) {
+    let encodedArguments = [
+        encoders.uInt64(antenna)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Antenna_get_CanTransmit', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether partial data transmission is permitted.
+ * @param {Long} antenna - A long value representing the id for the SpaceCenter.Antenna
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.antennaGetAllowPartial = function antennaGetAllowPartial(antenna) {
+    let encodedArguments = [
+        encoders.uInt64(antenna)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Antenna_get_AllowPartial', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether partial data transmission is permitted.
+ * @param {Long} antenna - A long value representing the id for the SpaceCenter.Antenna
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.antennaSetAllowPartial = function antennaSetAllowPartial(antenna, value) {
+    let encodedArguments = [
+        encoders.uInt64(antenna),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Antenna_set_AllowPartial', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The power of the antenna.
+ * @param {Long} antenna - A long value representing the id for the SpaceCenter.Antenna
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.antennaGetPower = function antennaGetPower(antenna) {
+    let encodedArguments = [
+        encoders.uInt64(antenna)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Antenna_get_Power', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the antenna can be combined with other antennae on the vessel
+ * to boost the power.
+ * @param {Long} antenna - A long value representing the id for the SpaceCenter.Antenna
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.antennaGetCombinable = function antennaGetCombinable(antenna) {
+    let encodedArguments = [
+        encoders.uInt64(antenna)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Antenna_get_Combinable', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Exponent used to calculate the combined power of multiple antennae on a vessel.
+ * @param {Long} antenna - A long value representing the id for the SpaceCenter.Antenna
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.antennaGetCombinableExponent = function antennaGetCombinableExponent(antenna) {
+    let encodedArguments = [
+        encoders.uInt64(antenna)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Antenna_get_CombinableExponent', encodedArguments),
+        decode: decoders.double
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Interval between sending packets in seconds.
+ * @param {Long} antenna - A long value representing the id for the SpaceCenter.Antenna
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.antennaGetPacketInterval = function antennaGetPacketInterval(antenna) {
+    let encodedArguments = [
+        encoders.uInt64(antenna)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Antenna_get_PacketInterval', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Amount of data sent per packet in Mits.
+ * @param {Long} antenna - A long value representing the id for the SpaceCenter.Antenna
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.antennaGetPacketSize = function antennaGetPacketSize(antenna) {
+    let encodedArguments = [
+        encoders.uInt64(antenna)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Antenna_get_PacketSize', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Units of electric charge consumed per packet sent.
+ * @param {Long} antenna - A long value representing the id for the SpaceCenter.Antenna
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.antennaGetPacketResourceCost = function antennaGetPacketResourceCost(antenna) {
+    let encodedArguments = [
+        encoders.uInt64(antenna)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Antenna_get_PacketResourceCost', encodedArguments),
         decode: decoders.double
     };
 };
@@ -5730,6 +8484,44 @@ module.exports.controlSurfaceSetRollEnabled = function controlSurfaceSetRollEnab
 
 /**
  * @augments SpaceCenter
+ * @description The authority limiter for the control surface, which controls how far the
+ * control surface will move.
+ * @param {Long} controlSurface - A long value representing the id for the SpaceCenter.ControlSurface
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.controlSurfaceGetAuthorityLimiter = function controlSurfaceGetAuthorityLimiter(controlSurface) {
+    let encodedArguments = [
+        encoders.uInt64(controlSurface)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ControlSurface_get_AuthorityLimiter', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The authority limiter for the control surface, which controls how far the
+ * control surface will move.
+ * @param {Long} controlSurface - A long value representing the id for the SpaceCenter.ControlSurface
+ * @param {number} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.controlSurfaceSetAuthorityLimiter = function controlSurfaceSetAuthorityLimiter(controlSurface, value) {
+    let encodedArguments = [
+        encoders.uInt64(controlSurface),
+        encoders.float(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ControlSurface_set_AuthorityLimiter', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
  * @description Whether the control surface movement is inverted.
  * @param {Long} controlSurface - A long value representing the id for the SpaceCenter.ControlSurface
  * @result {boolean}
@@ -5819,9 +8611,9 @@ module.exports.controlSurfaceGetSurfaceArea = function controlSurfaceGetSurfaceA
 
 /**
  * @augments SpaceCenter
- * @description The available torque in the positive pitch, roll and yaw axes and
- * negative pitch, roll and yaw axes of the vessel, in Newton meters.
- * These axes correspond to the coordinate axes of the {@link M:SpaceCenter.Vessel.ReferenceFrame}.
+ * @description The available torque, in Newton meters, that can be produced by this control surface,
+ * in the positive and negative pitch, roll and yaw axes of the vessel. These axes
+ * correspond to the coordinate axes of the {@link M:SpaceCenter.Vessel.ReferenceFrame}.
  * @param {Long} controlSurface - A long value representing the id for the SpaceCenter.ControlSurface
  * @result {{{number, number, number}, {number, number, number}}}
  * @returns {{call :Object, decode: function}}
@@ -5863,6 +8655,9 @@ module.exports.controlSurfaceGetAvailableTorque = function controlSurfaceGetAvai
  * @augments SpaceCenter
  * @description Fires the decoupler. Returns the new vessel created when the decoupler fires.
  * Throws an exception if the decoupler has already fired.
+ *  When called, the active vessel may change. It is therefore possible that,
+ * after calling this function, the object(s) returned by previous call(s) to
+ * {@link M:SpaceCenter.ActiveVessel} no longer refer to the active vessel.
  * @param {Long} decoupler - A long value representing the id for the SpaceCenter.Decoupler
  * @result {Long} A long value representing the id for the SpaceCenter.Vessel
  * @returns {{call :Object, decode: function}}
@@ -5950,7 +8745,9 @@ module.exports.decouplerGetImpulse = function decouplerGetImpulse(decoupler) {
  * @description Undocks the docking port and returns the new {@link T:SpaceCenter.Vessel} that is created.
  * This method can be called for either docking port in a docked pair.
  * Throws an exception if the docking port is not docked to anything.
- *  After undocking, the active vessel may change. See {@link M:SpaceCenter.ActiveVessel}.
+ *  When called, the active vessel may change. It is therefore possible that,
+ * after calling this function, the object(s) returned by previous call(s) to
+ * {@link M:SpaceCenter.ActiveVessel} no longer refer to the active vessel.
  * @param {Long} dockingPort - A long value representing the id for the SpaceCenter.DockingPort
  * @result {Long} A long value representing the id for the SpaceCenter.Vessel
  * @returns {{call :Object, decode: function}}
@@ -5967,7 +8764,10 @@ module.exports.dockingPortUndock = function dockingPortUndock(dockingPort) {
 
 /**
  * @augments SpaceCenter
- * @description The position of the docking port in the given reference frame.
+ * @description The position of the docking port, in the given reference frame.
+ * Returns: The position as a vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * position vector is in.</param>
  * @param {Long} dockingPort - A long value representing the id for the SpaceCenter.DockingPort
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -5995,6 +8795,9 @@ module.exports.dockingPortPosition = function dockingPortPosition(dockingPort, r
 /**
  * @augments SpaceCenter
  * @description The direction that docking port points in, in the given reference frame.
+ * Returns: The direction as a unit vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * direction is in.</param>
  * @param {Long} dockingPort - A long value representing the id for the SpaceCenter.DockingPort
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -6022,6 +8825,9 @@ module.exports.dockingPortDirection = function dockingPortDirection(dockingPort,
 /**
  * @augments SpaceCenter
  * @description The rotation of the docking port, in the given reference frame.
+ * Returns: The rotation as a quaternion of the form <math>(x, y, z, w)</math>.
+ * <param name="referenceFrame">The reference frame that the returned
+ * rotation is in.</param>
  * @param {Long} dockingPort - A long value representing the id for the SpaceCenter.DockingPort
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number, number}}
@@ -6090,7 +8896,7 @@ module.exports.dockingPortGetState = function dockingPortGetState(dockingPort) {
 
 /**
  * @augments SpaceCenter
- * @description The part that this docking port is docked to. Returns <c>null</c> if this
+ * @description The part that this docking port is docked to. Returns null if this
  * docking port is not docked to anything.
  * @param {Long} dockingPort - A long value representing the id for the SpaceCenter.DockingPort
  * @result {Long} A long value representing the id for the SpaceCenter.Part
@@ -6144,10 +8950,10 @@ module.exports.dockingPortGetHasShield = function dockingPortGetHasShield(dockin
 /**
  * @augments SpaceCenter
  * @description The state of the docking ports shield, if it has one.
- *
- * Returns <c>true</c> if the docking port has a shield, and the shield is
- * closed. Otherwise returns <c>false</c>. When set to <c>true</c>, the shield is
- * closed, and when set to <c>false</c> the shield is opened. If the docking
+ * 
+ * Returns true if the docking port has a shield, and the shield is
+ * closed. Otherwise returns false. When set to true, the shield is
+ * closed, and when set to false the shield is opened. If the docking
  * port does not have a shield, setting this attribute has no effect.
  * @param {Long} dockingPort - A long value representing the id for the SpaceCenter.DockingPort
  * @result {boolean}
@@ -6166,10 +8972,10 @@ module.exports.dockingPortGetShielded = function dockingPortGetShielded(dockingP
 /**
  * @augments SpaceCenter
  * @description The state of the docking ports shield, if it has one.
- *
- * Returns <c>true</c> if the docking port has a shield, and the shield is
- * closed. Otherwise returns <c>false</c>. When set to <c>true</c>, the shield is
- * closed, and when set to <c>false</c> the shield is opened. If the docking
+ * 
+ * Returns true if the docking port has a shield, and the shield is
+ * closed. Otherwise returns false. When set to true, the shield is
+ * closed, and when set to false the shield is opened. If the docking
  * port does not have a shield, setting this attribute has no effect.
  * @param {Long} dockingPort - A long value representing the id for the SpaceCenter.DockingPort
  * @param {boolean} value
@@ -6191,7 +8997,11 @@ module.exports.dockingPortSetShielded = function dockingPortSetShielded(dockingP
  * @augments SpaceCenter
  * @description The reference frame that is fixed relative to this docking port, and
  * oriented with the port.
- * <list type="bullet"><item><description>The origin is at the position of the docking port.</description></item><item><description>The axes rotate with the docking port.</description></item><item><description>The x-axis points out to the right side of the docking port.</description></item><item><description>The y-axis points in the direction the docking port is facing.</description></item><item><description>The z-axis points out of the bottom off the docking port.</description></item></list><remarks>
+ * <list type="bullet"><item><description>The origin is at the position of the docking port.
+ * </description></item><item><description>The axes rotate with the docking port.</description></item><item><description>The x-axis points out to the right side of the docking port.
+ * </description></item><item><description>The y-axis points in the direction the docking port is facing.
+ * </description></item><item><description>The z-axis points out of the bottom off the docking port.
+ * </description></item></list><remarks>
  * This reference frame is not necessarily equivalent to the reference frame
  * for the part, returned by {@link M:SpaceCenter.Part.ReferenceFrame}.
  * @param {Long} dockingPort - A long value representing the id for the SpaceCenter.DockingPort
@@ -6302,7 +9112,8 @@ module.exports.engineGetThrust = function engineGetThrust(engine) {
  * @description The amount of thrust, in Newtons, that would be produced by the engine
  * when activated and with its throttle set to 100%.
  * Returns zero if the engine does not have any fuel.
- * Takes the engine's current {@link M:SpaceCenter.Engine.ThrustLimit} and atmospheric conditions into account.
+ * Takes the engine's current {@link M:SpaceCenter.Engine.ThrustLimit} and atmospheric conditions
+ * into account.
  * @param {Long} engine - A long value representing the id for the SpaceCenter.Engine
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -6524,8 +9335,8 @@ module.exports.engineGetPropellants = function engineGetPropellants(engine) {
  * @augments SpaceCenter
  * @description The ratio of resources that the engine consumes. A dictionary mapping resource names
  * to the ratio at which they are consumed by the engine.
- *  For example, if the ratios are 0.6 for LiquidFuel and 0.4 for Oxidizer, then for every 0.6 units of
- * LiquidFuel that the engine burns, it will burn 0.4 units of Oxidizer.
+ *  For example, if the ratios are 0.6 for LiquidFuel and 0.4 for Oxidizer, then for every
+ * 0.6 units of LiquidFuel that the engine burns, it will burn 0.4 units of Oxidizer.
  * @param {Long} engine - A long value representing the id for the SpaceCenter.Engine
  * @result {key : number}
  * @returns {{call :Object, decode: function}}
@@ -6588,7 +9399,7 @@ module.exports.engineGetThrottle = function engineGetThrottle(engine) {
 /**
  * @augments SpaceCenter
  * @description Whether the {@link M:SpaceCenter.Control.Throttle} affects the engine. For example,
- * this is <c>true</c> for liquid fueled rockets, and <c>false</c> for solid rocket
+ * this is true for liquid fueled rockets, and false for solid rocket
  * boosters.
  * @param {Long} engine - A long value representing the id for the SpaceCenter.Engine
  * @result {boolean}
@@ -6607,8 +9418,8 @@ module.exports.engineGetThrottleLocked = function engineGetThrottleLocked(engine
 /**
  * @augments SpaceCenter
  * @description Whether the engine can be restarted once shutdown. If the engine cannot be shutdown,
- * returns <c>false</c>. For example, this is <c>true</c> for liquid fueled rockets
- * and <c>false</c> for solid rocket boosters.
+ * returns false. For example, this is true for liquid fueled rockets
+ * and false for solid rocket boosters.
  * @param {Long} engine - A long value representing the id for the SpaceCenter.Engine
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
@@ -6626,7 +9437,7 @@ module.exports.engineGetCanRestart = function engineGetCanRestart(engine) {
 /**
  * @augments SpaceCenter
  * @description Whether the engine can be shutdown once activated. For example, this is
- * <c>true</c> for liquid fueled rockets and <c>false</c> for solid rocket boosters.
+ * true for liquid fueled rockets and false for solid rocket boosters.
  * @param {Long} engine - A long value representing the id for the SpaceCenter.Engine
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
@@ -6868,8 +9679,9 @@ module.exports.engineSetGimbalLimit = function engineSetGimbalLimit(engine, valu
 
 /**
  * @augments SpaceCenter
- * @description The available torque in the pitch, roll and yaw axes of the vessel, in Newton meters.
- * These axes correspond to the coordinate axes of the {@link M:SpaceCenter.Vessel.ReferenceFrame}.
+ * @description The available torque, in Newton meters, that can be produced by this engine,
+ * in the positive and negative pitch, roll and yaw axes of the vessel. These axes
+ * correspond to the coordinate axes of the {@link M:SpaceCenter.Vessel.ReferenceFrame}.
  * Returns zero if the engine is inactive, or not gimballed.
  * @param {Long} engine - A long value representing the id for the SpaceCenter.Engine
  * @result {{{number, number, number}, {number, number, number}}}
@@ -7120,8 +9932,8 @@ module.exports.experimentGetBiome = function experimentGetBiome(experiment) {
 
 /**
  * @augments SpaceCenter
- * @description Containing information on the corresponding specific science result for the current conditions.
- * Returns null if experiment is unavailable.
+ * @description Containing information on the corresponding specific science result for the current
+ * conditions. Returns null if the experiment is unavailable.
  * @param {Long} experiment - A long value representing the id for the SpaceCenter.Experiment
  * @result {Long} A long value representing the id for the SpaceCenter.ScienceSubject
  * @returns {{call :Object, decode: function}}
@@ -7223,7 +10035,9 @@ module.exports.forceGetPart = function forceGetPart(force) {
 
 /**
  * @augments SpaceCenter
- * @description The force vector. The magnitude of the vector is the strength of the force in Newtons.
+ * @description The force vector, in Newtons.
+ * Returns: A vector pointing in the direction that the force acts,
+ * with its magnitude equal to the strength of the force in Newtons.
  * @param {Long} force - A long value representing the id for the SpaceCenter.Force
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -7248,7 +10062,9 @@ module.exports.forceGetForceVector = function forceGetForceVector(force) {
 
 /**
  * @augments SpaceCenter
- * @description The force vector. The magnitude of the vector is the strength of the force in Newtons.
+ * @description The force vector, in Newtons.
+ * Returns: A vector pointing in the direction that the force acts,
+ * with its magnitude equal to the strength of the force in Newtons.
  * @param {Long} force - A long value representing the id for the SpaceCenter.Force
  * @param {{number, number, number}} value
  * @result {void}
@@ -7267,7 +10083,8 @@ module.exports.forceSetForceVector = function forceSetForceVector(force, value) 
 
 /**
  * @augments SpaceCenter
- * @description The position at which the force acts.
+ * @description The position at which the force acts, in reference frame {@link T:SpaceCenter.ReferenceFrame}.
+ * Returns: The position as a vector.
  * @param {Long} force - A long value representing the id for the SpaceCenter.Force
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -7292,7 +10109,8 @@ module.exports.forceGetPosition = function forceGetPosition(force) {
 
 /**
  * @augments SpaceCenter
- * @description The position at which the force acts.
+ * @description The position at which the force acts, in reference frame {@link T:SpaceCenter.ReferenceFrame}.
+ * Returns: The position as a vector.
  * @param {Long} force - A long value representing the id for the SpaceCenter.Force
  * @param {{number, number, number}} value
  * @result {void}
@@ -7451,218 +10269,6 @@ module.exports.intakeGetArea = function intakeGetArea(intake) {
 
 /**
  * @augments SpaceCenter
- * @description The part object for this landing gear.
- * @param {Long} landingGear - A long value representing the id for the SpaceCenter.LandingGear
- * @result {Long} A long value representing the id for the SpaceCenter.Part
- * @returns {{call :Object, decode: function}}
- */
-module.exports.landingGearGetPart = function landingGearGetPart(landingGear) {
-    let encodedArguments = [
-        encoders.uInt64(landingGear)
-    ];
-    return {
-        call: buildProcedureCall('SpaceCenter', 'LandingGear_get_Part', encodedArguments),
-        decode: decoders.uInt64
-    };
-};
-
-/**
- * @augments SpaceCenter
- * @description Whether the landing gear is deployable.
- * @param {Long} landingGear - A long value representing the id for the SpaceCenter.LandingGear
- * @result {boolean}
- * @returns {{call :Object, decode: function}}
- */
-module.exports.landingGearGetDeployable = function landingGearGetDeployable(landingGear) {
-    let encodedArguments = [
-        encoders.uInt64(landingGear)
-    ];
-    return {
-        call: buildProcedureCall('SpaceCenter', 'LandingGear_get_Deployable', encodedArguments),
-        decode: decoders.bool
-    };
-};
-
-/**
- * @augments SpaceCenter
- * @description Gets the current state of the landing gear.
- *  Fixed landing gear are always deployed.
- * @param {Long} landingGear - A long value representing the id for the SpaceCenter.LandingGear
- * @result {Long} A long value representing the id for the SpaceCenter.LandingGearState
- * @returns {{call :Object, decode: function}}
- */
-module.exports.landingGearGetState = function landingGearGetState(landingGear) {
-    let encodedArguments = [
-        encoders.uInt64(landingGear)
-    ];
-    return {
-        call: buildProcedureCall('SpaceCenter', 'LandingGear_get_State', encodedArguments),
-        decode: decoders.enum({
-            0: 'Deployed',
-            1: 'Retracted',
-            2: 'Deploying',
-            3: 'Retracting',
-            4: 'Broken'
-        })
-    };
-};
-
-/**
- * @augments SpaceCenter
- * @description Whether the landing gear is deployed.
- *  Fixed landing gear are always deployed.
- * Returns an error if you try to deploy fixed landing gear.
- * @param {Long} landingGear - A long value representing the id for the SpaceCenter.LandingGear
- * @result {boolean}
- * @returns {{call :Object, decode: function}}
- */
-module.exports.landingGearGetDeployed = function landingGearGetDeployed(landingGear) {
-    let encodedArguments = [
-        encoders.uInt64(landingGear)
-    ];
-    return {
-        call: buildProcedureCall('SpaceCenter', 'LandingGear_get_Deployed', encodedArguments),
-        decode: decoders.bool
-    };
-};
-
-/**
- * @augments SpaceCenter
- * @description Whether the landing gear is deployed.
- *  Fixed landing gear are always deployed.
- * Returns an error if you try to deploy fixed landing gear.
- * @param {Long} landingGear - A long value representing the id for the SpaceCenter.LandingGear
- * @param {boolean} value
- * @result {void}
- * @returns {void}
- */
-module.exports.landingGearSetDeployed = function landingGearSetDeployed(landingGear, value) {
-    let encodedArguments = [
-        encoders.uInt64(landingGear),
-        encoders.bool(value)
-    ];
-    return {
-        call: buildProcedureCall('SpaceCenter', 'LandingGear_set_Deployed', encodedArguments),
-        decode: null
-    };
-};
-
-/**
- * @augments SpaceCenter
- * @description Returns whether the gear is touching the ground.
- * @param {Long} landingGear - A long value representing the id for the SpaceCenter.LandingGear
- * @result {boolean}
- * @returns {{call :Object, decode: function}}
- */
-module.exports.landingGearGetIsGrounded = function landingGearGetIsGrounded(landingGear) {
-    let encodedArguments = [
-        encoders.uInt64(landingGear)
-    ];
-    return {
-        call: buildProcedureCall('SpaceCenter', 'LandingGear_get_IsGrounded', encodedArguments),
-        decode: decoders.bool
-    };
-};
-
-/**
- * @augments SpaceCenter
- * @description The part object for this landing leg.
- * @param {Long} landingLeg - A long value representing the id for the SpaceCenter.LandingLeg
- * @result {Long} A long value representing the id for the SpaceCenter.Part
- * @returns {{call :Object, decode: function}}
- */
-module.exports.landingLegGetPart = function landingLegGetPart(landingLeg) {
-    let encodedArguments = [
-        encoders.uInt64(landingLeg)
-    ];
-    return {
-        call: buildProcedureCall('SpaceCenter', 'LandingLeg_get_Part', encodedArguments),
-        decode: decoders.uInt64
-    };
-};
-
-/**
- * @augments SpaceCenter
- * @description The current state of the landing leg.
- * @param {Long} landingLeg - A long value representing the id for the SpaceCenter.LandingLeg
- * @result {Long} A long value representing the id for the SpaceCenter.LandingLegState
- * @returns {{call :Object, decode: function}}
- */
-module.exports.landingLegGetState = function landingLegGetState(landingLeg) {
-    let encodedArguments = [
-        encoders.uInt64(landingLeg)
-    ];
-    return {
-        call: buildProcedureCall('SpaceCenter', 'LandingLeg_get_State', encodedArguments),
-        decode: decoders.enum({
-            0: 'Deployed',
-            1: 'Retracted',
-            2: 'Deploying',
-            3: 'Retracting',
-            4: 'Broken'
-        })
-    };
-};
-
-/**
- * @augments SpaceCenter
- * @description Whether the landing leg is deployed.
- *  Fixed landing legs are always deployed.
- * Returns an error if you try to deploy fixed landing gear.
- * @param {Long} landingLeg - A long value representing the id for the SpaceCenter.LandingLeg
- * @result {boolean}
- * @returns {{call :Object, decode: function}}
- */
-module.exports.landingLegGetDeployed = function landingLegGetDeployed(landingLeg) {
-    let encodedArguments = [
-        encoders.uInt64(landingLeg)
-    ];
-    return {
-        call: buildProcedureCall('SpaceCenter', 'LandingLeg_get_Deployed', encodedArguments),
-        decode: decoders.bool
-    };
-};
-
-/**
- * @augments SpaceCenter
- * @description Whether the landing leg is deployed.
- *  Fixed landing legs are always deployed.
- * Returns an error if you try to deploy fixed landing gear.
- * @param {Long} landingLeg - A long value representing the id for the SpaceCenter.LandingLeg
- * @param {boolean} value
- * @result {void}
- * @returns {void}
- */
-module.exports.landingLegSetDeployed = function landingLegSetDeployed(landingLeg, value) {
-    let encodedArguments = [
-        encoders.uInt64(landingLeg),
-        encoders.bool(value)
-    ];
-    return {
-        call: buildProcedureCall('SpaceCenter', 'LandingLeg_set_Deployed', encodedArguments),
-        decode: null
-    };
-};
-
-/**
- * @augments SpaceCenter
- * @description Returns whether the leg is touching the ground.
- * @param {Long} landingLeg - A long value representing the id for the SpaceCenter.LandingLeg
- * @result {boolean}
- * @returns {{call :Object, decode: function}}
- */
-module.exports.landingLegGetIsGrounded = function landingLegGetIsGrounded(landingLeg) {
-    let encodedArguments = [
-        encoders.uInt64(landingLeg)
-    ];
-    return {
-        call: buildProcedureCall('SpaceCenter', 'LandingLeg_get_IsGrounded', encodedArguments),
-        decode: decoders.bool
-    };
-};
-
-/**
- * @augments SpaceCenter
  * @description Releases the docking clamp. Has no effect if the clamp has already been released.
  * @param {Long} launchClamp - A long value representing the id for the SpaceCenter.LaunchClamp
  * @result {void}
@@ -7692,6 +10298,120 @@ module.exports.launchClampGetPart = function launchClampGetPart(launchClamp) {
     return {
         call: buildProcedureCall('SpaceCenter', 'LaunchClamp_get_Part', encodedArguments),
         decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The part object for this landing leg.
+ * @param {Long} leg - A long value representing the id for the SpaceCenter.Leg
+ * @result {Long} A long value representing the id for the SpaceCenter.Part
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.legGetPart = function legGetPart(leg) {
+    let encodedArguments = [
+        encoders.uInt64(leg)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Leg_get_Part', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The current state of the landing leg.
+ * @param {Long} leg - A long value representing the id for the SpaceCenter.Leg
+ * @result {Long} A long value representing the id for the SpaceCenter.LegState
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.legGetState = function legGetState(leg) {
+    let encodedArguments = [
+        encoders.uInt64(leg)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Leg_get_State', encodedArguments),
+        decode: decoders.enum({
+            0: 'Deployed',
+            1: 'Retracted',
+            2: 'Deploying',
+            3: 'Retracting',
+            4: 'Broken'
+        })
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the leg is deployable.
+ * @param {Long} leg - A long value representing the id for the SpaceCenter.Leg
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.legGetDeployable = function legGetDeployable(leg) {
+    let encodedArguments = [
+        encoders.uInt64(leg)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Leg_get_Deployable', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the landing leg is deployed.
+ *  Fixed landing legs are always deployed.
+ * Returns an error if you try to deploy fixed landing gear.
+ * @param {Long} leg - A long value representing the id for the SpaceCenter.Leg
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.legGetDeployed = function legGetDeployed(leg) {
+    let encodedArguments = [
+        encoders.uInt64(leg)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Leg_get_Deployed', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the landing leg is deployed.
+ *  Fixed landing legs are always deployed.
+ * Returns an error if you try to deploy fixed landing gear.
+ * @param {Long} leg - A long value representing the id for the SpaceCenter.Leg
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.legSetDeployed = function legSetDeployed(leg, value) {
+    let encodedArguments = [
+        encoders.uInt64(leg),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Leg_set_Deployed', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Returns whether the leg is touching the ground.
+ * @param {Long} leg - A long value representing the id for the SpaceCenter.Leg
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.legGetIsGrounded = function legGetIsGrounded(leg) {
+    let encodedArguments = [
+        encoders.uInt64(leg)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Leg_get_IsGrounded', encodedArguments),
+        decode: decoders.bool
     };
 };
 
@@ -7811,7 +10531,7 @@ module.exports.lightGetPowerUsage = function lightGetPowerUsage(light) {
 
 /**
  * @augments SpaceCenter
- * @description Returns <c>true</c> if the module has a field with the given name.
+ * @description Returns true if the module has a field with the given name.
  * @param {Long} module - A long value representing the id for the SpaceCenter.Module
  * @param {string} name - Name of the field.
  * @result {boolean}
@@ -7931,7 +10651,7 @@ module.exports.moduleResetField = function moduleResetField(module, name) {
 
 /**
  * @augments SpaceCenter
- * @description <summary><c>true</c> if the module has an event with the given name.
+ * @description <summary>true if the module has an event with the given name.
  * @param {Long} module - A long value representing the id for the SpaceCenter.Module
  * @param {string} name
  * @result {boolean}
@@ -7950,7 +10670,8 @@ module.exports.moduleHasEvent = function moduleHasEvent(module, name) {
 
 /**
  * @augments SpaceCenter
- * @description Trigger the named event. Equivalent to clicking the button in the right-click menu of the part.
+ * @description Trigger the named event. Equivalent to clicking the button in the right-click menu
+ * of the part.
  * @param {Long} module - A long value representing the id for the SpaceCenter.Module
  * @param {string} name
  * @result {void}
@@ -7969,7 +10690,7 @@ module.exports.moduleTriggerEvent = function moduleTriggerEvent(module, name) {
 
 /**
  * @augments SpaceCenter
- * @description <summary><c>true</c> if the part has an action with the given name.
+ * @description <summary>true if the part has an action with the given name.
  * @param {Long} module - A long value representing the id for the SpaceCenter.Module
  * @param {string} name
  * @result {boolean}
@@ -8092,8 +10813,8 @@ module.exports.moduleGetEvents = function moduleGetEvents(module) {
 
 /**
  * @augments SpaceCenter
- * @description A list of all the names of the modules actions. These are the parts actions that can be assigned
- * to action groups in the in-game editor.
+ * @description A list of all the names of the modules actions. These are the parts actions that can
+ * be assigned to action groups in the in-game editor.
  * @param {Long} module - A long value representing the id for the SpaceCenter.Module
  * @result {string[]}
  * @returns {{call :Object, decode: function}}
@@ -8134,6 +10855,24 @@ module.exports.parachuteDeploy = function parachuteDeploy(parachute) {
 
 /**
  * @augments SpaceCenter
+ * @description Deploys the parachute. This has no effect if the parachute has already
+ * been armed or deployed. Only applicable to RealChutes parachutes.
+ * @param {Long} parachute - A long value representing the id for the SpaceCenter.Parachute
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.parachuteArm = function parachuteArm(parachute) {
+    let encodedArguments = [
+        encoders.uInt64(parachute)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Parachute_Arm', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
  * @description The part object for this parachute.
  * @param {Long} parachute - A long value representing the id for the SpaceCenter.Parachute
  * @result {Long} A long value representing the id for the SpaceCenter.Part
@@ -8168,6 +10907,24 @@ module.exports.parachuteGetDeployed = function parachuteGetDeployed(parachute) {
 
 /**
  * @augments SpaceCenter
+ * @description Whether the parachute has been armed or deployed. Only applicable to
+ * RealChutes parachutes.
+ * @param {Long} parachute - A long value representing the id for the SpaceCenter.Parachute
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.parachuteGetArmed = function parachuteGetArmed(parachute) {
+    let encodedArguments = [
+        encoders.uInt64(parachute)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Parachute_get_Armed', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
  * @description The current state of the parachute.
  * @param {Long} parachute - A long value representing the id for the SpaceCenter.Parachute
  * @result {Long} A long value representing the id for the SpaceCenter.ParachuteState
@@ -8180,11 +10937,12 @@ module.exports.parachuteGetState = function parachuteGetState(parachute) {
     return {
         call: buildProcedureCall('SpaceCenter', 'Parachute_get_State', encodedArguments),
         decode: decoders.enum({
-            0: 'Active',
-            1: 'Cut',
-            2: 'Deployed',
+            0: 'Stowed',
+            1: 'Armed',
+            2: 'Active',
             3: 'SemiDeployed',
-            4: 'Stowed'
+            4: 'Deployed',
+            5: 'Cut'
         })
     };
 };
@@ -8192,6 +10950,7 @@ module.exports.parachuteGetState = function parachuteGetState(parachute) {
 /**
  * @augments SpaceCenter
  * @description The altitude at which the parachute will full deploy, in meters.
+ * Only applicable to stock parachutes.
  * @param {Long} parachute - A long value representing the id for the SpaceCenter.Parachute
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -8209,6 +10968,7 @@ module.exports.parachuteGetDeployAltitude = function parachuteGetDeployAltitude(
 /**
  * @augments SpaceCenter
  * @description The altitude at which the parachute will full deploy, in meters.
+ * Only applicable to stock parachutes.
  * @param {Long} parachute - A long value representing the id for the SpaceCenter.Parachute
  * @param {number} value
  * @result {void}
@@ -8228,6 +10988,7 @@ module.exports.parachuteSetDeployAltitude = function parachuteSetDeployAltitude(
 /**
  * @augments SpaceCenter
  * @description The minimum pressure at which the parachute will semi-deploy, in atmospheres.
+ * Only applicable to stock parachutes.
  * @param {Long} parachute - A long value representing the id for the SpaceCenter.Parachute
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -8245,6 +11006,7 @@ module.exports.parachuteGetDeployMinPressure = function parachuteGetDeployMinPre
 /**
  * @augments SpaceCenter
  * @description The minimum pressure at which the parachute will semi-deploy, in atmospheres.
+ * Only applicable to stock parachutes.
  * @param {Long} parachute - A long value representing the id for the SpaceCenter.Parachute
  * @param {number} value
  * @result {void}
@@ -8264,6 +11026,9 @@ module.exports.parachuteSetDeployMinPressure = function parachuteSetDeployMinPre
 /**
  * @augments SpaceCenter
  * @description The position of the part in the given reference frame.
+ * Returns: The position as a vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * position vector is in.</param>
  *  This is a fixed position in the part, defined by the parts model.
  * It s not necessarily the same as the parts center of mass.
  * Use {@link M:SpaceCenter.Part.CenterOfMass} to get the parts center of mass.
@@ -8295,6 +11060,9 @@ module.exports.partPosition = function partPosition(part, referenceFrame) {
  * @augments SpaceCenter
  * @description The position of the parts center of mass in the given reference frame.
  * If the part is physicsless, this is equivalent to {@link M:SpaceCenter.Part.Position}.
+ * Returns: The position as a vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * position vector is in.</param>
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -8321,10 +11089,12 @@ module.exports.partCenterOfMass = function partCenterOfMass(part, referenceFrame
 
 /**
  * @augments SpaceCenter
- * @description The axis-aligned bounding box of the vessel in the given reference frame.
- * Returns the minimum and maximum vertices of the box.
- *
- *  This is computed from the collision meshes of the part.
+ * @description The axis-aligned bounding box of the part in the given reference frame.
+ * Returns: The positions of the minimum and maximum vertices of the box,
+ * as position vectors.
+ * <param name="referenceFrame">The reference frame that the returned
+ * position vectors are in.</param>
+ *  This is computed from the collision mesh of the part.
  * If the part is not collidable, the box has zero volume and is centered on
  * the {@link M:SpaceCenter.Part.Position} of the part.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
@@ -8368,7 +11138,10 @@ module.exports.partBoundingBox = function partBoundingBox(part, referenceFrame) 
 
 /**
  * @augments SpaceCenter
- * @description The direction of the part in the given reference frame.
+ * @description The direction the part points in, in the given reference frame.
+ * Returns: The direction as a unit vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * direction is in.</param>
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -8395,7 +11168,11 @@ module.exports.partDirection = function partDirection(part, referenceFrame) {
 
 /**
  * @augments SpaceCenter
- * @description The velocity of the part in the given reference frame.
+ * @description The linear velocity of the part in the given reference frame.
+ * Returns: The velocity as a vector. The vector points in the direction of travel,
+ * and its magnitude is the speed of the body in meters per second.
+ * <param name="referenceFrame">The reference frame that the returned
+ * velocity vector is in.</param>
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -8422,7 +11199,10 @@ module.exports.partVelocity = function partVelocity(part, referenceFrame) {
 
 /**
  * @augments SpaceCenter
- * @description The rotation of the part in the given reference frame.
+ * @description The rotation of the part, in the given reference frame.
+ * Returns: The rotation as a quaternion of the form <math>(x, y, z, w)</math>.
+ * <param name="referenceFrame">The reference frame that the returned
+ * rotation is in.</param>
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number, number}}
@@ -8451,10 +11231,16 @@ module.exports.partRotation = function partRotation(part, referenceFrame) {
 /**
  * @augments SpaceCenter
  * @description Exert a constant force on the part, acting at the given position.
- * Returns an object that can be used to remove or modify the force.
+ * Returns: An object that can be used to remove or modify the force.
+ * <param name="force">A vector pointing in the direction that the force acts,
+ * with its magnitude equal to the strength of the force in Newtons.</param>
+ * 
+ * <param name="referenceFrame">The reference frame that the
+ * force and position are in.</param>
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
- * @param {{number, number, number}} force
- * @param {{number, number, number}} position
+ * @param {{number, number, number}} force - A vector pointing in the direction that the force acts,
+with its magnitude equal to the strength of the force in Newtons.
+ * @param {{number, number, number}} position - The position at which the force acts, as a vector.
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {Long} A long value representing the id for the SpaceCenter.Force
  * @returns {{call :Object, decode: function}}
@@ -8475,10 +11261,16 @@ module.exports.partAddForce = function partAddForce(part, force, position, refer
 /**
  * @augments SpaceCenter
  * @description Exert an instantaneous force on the part, acting at the given position.
- *  The force is applied instantaneously in a single physics update.
+ * <param name="force">A vector pointing in the direction that the force acts,
+ * with its magnitude equal to the strength of the force in Newtons.</param>
+ * 
+ * <param name="referenceFrame">The reference frame that the
+ * force and position are in.</param>
+ * <remarks>The force is applied instantaneously in a single physics update.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
- * @param {{number, number, number}} force
- * @param {{number, number, number}} position
+ * @param {{number, number, number}} force - A vector pointing in the direction that the force acts,
+with its magnitude equal to the strength of the force in Newtons.
+ * @param {{number, number, number}} position - The position at which the force acts, as a vector.
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {void}
  * @returns {void}
@@ -8499,7 +11291,7 @@ module.exports.partInstantaneousForce = function partInstantaneousForce(part, fo
 /**
  * @augments SpaceCenter
  * @description Internal name of the part, as used in
- * <a href="http://wiki.kerbalspaceprogram.com/wiki/CFG_File_Documentation">part cfg files</a>.
+ * <a href="https://wiki.kerbalspaceprogram.com/wiki/CFG_File_Documentation">part cfg files</a>.
  * For example "Mark1-2Pod".
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {string}
@@ -8534,9 +11326,12 @@ module.exports.partGetTitle = function partGetTitle(part) {
 
 /**
  * @augments SpaceCenter
- * @description The name tag for the part. Can be set to a custom string using the in-game user interface.
- *  This requires either the <a href="http://github.com/krpc/NameTag/releases/latest">NameTag</a> or
- * <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/61827-/">kOS</a> mods to be installed.
+ * @description The name tag for the part. Can be set to a custom string using the
+ * in-game user interface.
+ *  This requires either the
+ * <a href="https://github.com/krpc/NameTag/releases/latest">NameTag</a> or
+ * <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/61827-/">kOS</a>
+ * mod to be installed.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {string}
  * @returns {{call :Object, decode: function}}
@@ -8553,9 +11348,12 @@ module.exports.partGetTag = function partGetTag(part) {
 
 /**
  * @augments SpaceCenter
- * @description The name tag for the part. Can be set to a custom string using the in-game user interface.
- *  This requires either the <a href="http://github.com/krpc/NameTag/releases/latest">NameTag</a> or
- * <a href="http://forum.kerbalspaceprogram.com/index.php?/topic/61827-/">kOS</a> mods to be installed.
+ * @description The name tag for the part. Can be set to a custom string using the
+ * in-game user interface.
+ *  This requires either the
+ * <a href="https://github.com/krpc/NameTag/releases/latest">NameTag</a> or
+ * <a href="https://forum.kerbalspaceprogram.com/index.php?/topic/61827-/">kOS</a>
+ * mod to be installed.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @param {string} value
  * @result {void}
@@ -8610,7 +11408,7 @@ module.exports.partSetHighlighted = function partSetHighlighted(part, value) {
 
 /**
  * @augments SpaceCenter
- * @description The color used to highlight the part.
+ * @description The color used to highlight the part, as an RGB triple.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -8635,7 +11433,7 @@ module.exports.partGetHighlightColor = function partGetHighlightColor(part) {
 
 /**
  * @augments SpaceCenter
- * @description The color used to highlight the part.
+ * @description The color used to highlight the part, as an RGB triple.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @param {{number, number, number}} value
  * @result {void}
@@ -8688,8 +11486,9 @@ module.exports.partGetVessel = function partGetVessel(part) {
 
 /**
  * @augments SpaceCenter
- * @description The parts parent. Returns <c>null</c> if the part does not have a parent.
- * This, in combination with {@link M:SpaceCenter.Part.Children}, can be used to traverse the vessels parts tree.
+ * @description The parts parent. Returns null if the part does not have a parent.
+ * This, in combination with {@link M:SpaceCenter.Part.Children}, can be used to traverse the vessels
+ * parts tree.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.Part
  * @returns {{call :Object, decode: function}}
@@ -8707,7 +11506,8 @@ module.exports.partGetParent = function partGetParent(part) {
 /**
  * @augments SpaceCenter
  * @description The parts children. Returns an empty list if the part has no children.
- * This, in combination with {@link M:SpaceCenter.Part.Parent}, can be used to traverse the vessels parts tree.
+ * This, in combination with {@link M:SpaceCenter.Part.Parent}, can be used to traverse the vessels
+ * parts tree.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Part
  * @returns {{call :Object, decode: function}}
@@ -8731,7 +11531,7 @@ module.exports.partGetChildren = function partGetChildren(part) {
 /**
  * @augments SpaceCenter
  * @description Whether the part is axially attached to its parent, i.e. on the top
- * or bottom of its parent. If the part has no parent, returns <c>false</c>.
+ * or bottom of its parent. If the part has no parent, returns false.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
@@ -8749,7 +11549,7 @@ module.exports.partGetAxiallyAttached = function partGetAxiallyAttached(part) {
 /**
  * @augments SpaceCenter
  * @description Whether the part is radially attached to its parent, i.e. on the side of its parent.
- * If the part has no parent, returns <c>false</c>.
+ * If the part has no parent, returns false.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
@@ -8766,7 +11566,8 @@ module.exports.partGetRadiallyAttached = function partGetRadiallyAttached(part) 
 
 /**
  * @augments SpaceCenter
- * @description The stage in which this part will be activated. Returns -1 if the part is not activated by staging.
+ * @description The stage in which this part will be activated. Returns -1 if the part is not
+ * activated by staging.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -8783,7 +11584,8 @@ module.exports.partGetStage = function partGetStage(part) {
 
 /**
  * @augments SpaceCenter
- * @description The stage in which this part will be decoupled. Returns -1 if the part is never decoupled from the vessel.
+ * @description The stage in which this part will be decoupled. Returns -1 if the part is never
+ * decoupled from the vessel.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -8800,7 +11602,8 @@ module.exports.partGetDecoupleStage = function partGetDecoupleStage(part) {
 
 /**
  * @augments SpaceCenter
- * @description Whether the part is <a href="http://wiki.kerbalspaceprogram.com/wiki/Massless_part">massless</a>.
+ * @description Whether the part is
+ * <a href="https://wiki.kerbalspaceprogram.com/wiki/Massless_part">massless</a>.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
@@ -8835,7 +11638,8 @@ module.exports.partGetMass = function partGetMass(part) {
 
 /**
  * @augments SpaceCenter
- * @description The mass of the part, not including any resources it contains, in kilograms. Returns zero if the part is massless.
+ * @description The mass of the part, not including any resources it contains, in kilograms.
+ * Returns zero if the part is massless.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -8971,7 +11775,8 @@ module.exports.partGetMaxSkinTemperature = function partGetMaxSkinTemperature(pa
 
 /**
  * @augments SpaceCenter
- * @description A measure of how much energy it takes to increase the internal temperature of the part, in Joules per Kelvin.
+ * @description A measure of how much energy it takes to increase the internal temperature of the part,
+ * in Joules per Kelvin.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -8988,7 +11793,8 @@ module.exports.partGetThermalMass = function partGetThermalMass(part) {
 
 /**
  * @augments SpaceCenter
- * @description A measure of how much energy it takes to increase the skin temperature of the part, in Joules per Kelvin.
+ * @description A measure of how much energy it takes to increase the skin temperature of the part,
+ * in Joules per Kelvin.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -9005,7 +11811,8 @@ module.exports.partGetThermalSkinMass = function partGetThermalSkinMass(part) {
 
 /**
  * @augments SpaceCenter
- * @description A measure of how much energy it takes to increase the temperature of the resources contained in the part, in Joules per Kelvin.
+ * @description A measure of how much energy it takes to increase the temperature of the resources
+ * contained in the part, in Joules per Kelvin.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -9025,7 +11832,8 @@ module.exports.partGetThermalResourceMass = function partGetThermalResourceMass(
  * @description The rate at which heat energy is begin generated by the part.
  * For example, some engines generate heat by combusting fuel.
  * Measured in energy per unit time, or power, in Watts.
- * A positive value means the part is gaining heat energy, and negative means it is losing heat energy.
+ * A positive value means the part is gaining heat energy, and negative means it is losing
+ * heat energy.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -9042,9 +11850,10 @@ module.exports.partGetThermalInternalFlux = function partGetThermalInternalFlux(
 
 /**
  * @augments SpaceCenter
- * @description The rate at which heat energy is conducting into or out of the part via contact with other parts.
- * Measured in energy per unit time, or power, in Watts.
- * A positive value means the part is gaining heat energy, and negative means it is losing heat energy.
+ * @description The rate at which heat energy is conducting into or out of the part via contact with
+ * other parts. Measured in energy per unit time, or power, in Watts.
+ * A positive value means the part is gaining heat energy, and negative means it is
+ * losing heat energy.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -9061,9 +11870,10 @@ module.exports.partGetThermalConductionFlux = function partGetThermalConductionF
 
 /**
  * @augments SpaceCenter
- * @description The rate at which heat energy is convecting into or out of the part from the surrounding atmosphere.
- * Measured in energy per unit time, or power, in Watts.
- * A positive value means the part is gaining heat energy, and negative means it is losing heat energy.
+ * @description The rate at which heat energy is convecting into or out of the part from the
+ * surrounding atmosphere. Measured in energy per unit time, or power, in Watts.
+ * A positive value means the part is gaining heat energy, and negative means it is
+ * losing heat energy.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -9080,9 +11890,10 @@ module.exports.partGetThermalConvectionFlux = function partGetThermalConvectionF
 
 /**
  * @augments SpaceCenter
- * @description The rate at which heat energy is radiating into or out of the part from the surrounding environment.
- * Measured in energy per unit time, or power, in Watts.
- * A positive value means the part is gaining heat energy, and negative means it is losing heat energy.
+ * @description The rate at which heat energy is radiating into or out of the part from the surrounding
+ * environment. Measured in energy per unit time, or power, in Watts.
+ * A positive value means the part is gaining heat energy, and negative means it is
+ * losing heat energy.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -9170,7 +11981,8 @@ module.exports.partGetIsFuelLine = function partGetIsFuelLine(part) {
 
 /**
  * @augments SpaceCenter
- * @description The parts that are connected to this part via fuel lines, where the direction of the fuel line is into this part.
+ * @description The parts that are connected to this part via fuel lines, where the direction of the
+ * fuel line is into this part.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Part
  * @returns {{call :Object, decode: function}}
@@ -9193,7 +12005,8 @@ module.exports.partGetFuelLinesFrom = function partGetFuelLinesFrom(part) {
 
 /**
  * @augments SpaceCenter
- * @description The parts that are connected to this part via fuel lines, where the direction of the fuel line is out of this part.
+ * @description The parts that are connected to this part via fuel lines, where the direction of the
+ * fuel line is out of this part.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Part
  * @returns {{call :Object, decode: function}}
@@ -9239,7 +12052,24 @@ module.exports.partGetModules = function partGetModules(part) {
 
 /**
  * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.CargoBay} if the part is a cargo bay, otherwise <c>null</c>.
+ * @description A {@link T:SpaceCenter.Antenna} if the part is an antenna, otherwise null.
+ * @param {Long} part - A long value representing the id for the SpaceCenter.Part
+ * @result {Long} A long value representing the id for the SpaceCenter.Antenna
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.partGetAntenna = function partGetAntenna(part) {
+    let encodedArguments = [
+        encoders.uInt64(part)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Part_get_Antenna', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description A {@link T:SpaceCenter.CargoBay} if the part is a cargo bay, otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.CargoBay
  * @returns {{call :Object, decode: function}}
@@ -9256,7 +12086,8 @@ module.exports.partGetCargoBay = function partGetCargoBay(part) {
 
 /**
  * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.ControlSurface} if the part is an aerodynamic control surface, otherwise <c>null</c>.
+ * @description A {@link T:SpaceCenter.ControlSurface} if the part is an aerodynamic control surface,
+ * otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.ControlSurface
  * @returns {{call :Object, decode: function}}
@@ -9273,7 +12104,7 @@ module.exports.partGetControlSurface = function partGetControlSurface(part) {
 
 /**
  * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.Decoupler} if the part is a decoupler, otherwise <c>null</c>.
+ * @description A {@link T:SpaceCenter.Decoupler} if the part is a decoupler, otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.Decoupler
  * @returns {{call :Object, decode: function}}
@@ -9290,7 +12121,7 @@ module.exports.partGetDecoupler = function partGetDecoupler(part) {
 
 /**
  * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.DockingPort} if the part is a docking port, otherwise <c>null</c>.
+ * @description A {@link T:SpaceCenter.DockingPort} if the part is a docking port, otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.DockingPort
  * @returns {{call :Object, decode: function}}
@@ -9307,7 +12138,7 @@ module.exports.partGetDockingPort = function partGetDockingPort(part) {
 
 /**
  * @augments SpaceCenter
- * @description An {@link T:SpaceCenter.Engine} if the part is an engine, otherwise <c>null</c>.
+ * @description An {@link T:SpaceCenter.Engine} if the part is an engine, otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.Engine
  * @returns {{call :Object, decode: function}}
@@ -9324,7 +12155,7 @@ module.exports.partGetEngine = function partGetEngine(part) {
 
 /**
  * @augments SpaceCenter
- * @description An {@link T:SpaceCenter.Experiment} if the part is a science experiment, otherwise <c>null</c>.
+ * @description An {@link T:SpaceCenter.Experiment} if the part is a science experiment, otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.Experiment
  * @returns {{call :Object, decode: function}}
@@ -9341,7 +12172,7 @@ module.exports.partGetExperiment = function partGetExperiment(part) {
 
 /**
  * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.Fairing} if the part is a fairing, otherwise <c>null</c>.
+ * @description A {@link T:SpaceCenter.Fairing} if the part is a fairing, otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.Fairing
  * @returns {{call :Object, decode: function}}
@@ -9358,9 +12189,9 @@ module.exports.partGetFairing = function partGetFairing(part) {
 
 /**
  * @augments SpaceCenter
- * @description An {@link T:SpaceCenter.Intake} if the part is an intake, otherwise <c>null</c>.
- *  This includes any part that generates thrust. This covers many different types of engine,
- * including liquid fuel rockets, solid rocket boosters and jet engines.
+ * @description An {@link T:SpaceCenter.Intake} if the part is an intake, otherwise null.
+ *  This includes any part that generates thrust. This covers many different types
+ * of engine, including liquid fuel rockets, solid rocket boosters and jet engines.
  * For RCS thrusters see {@link T:SpaceCenter.RCS}.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.Intake
@@ -9378,41 +12209,24 @@ module.exports.partGetIntake = function partGetIntake(part) {
 
 /**
  * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.LandingGear} if the part is a landing gear, otherwise <c>null</c>.
+ * @description A {@link T:SpaceCenter.Leg} if the part is a landing leg, otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
- * @result {Long} A long value representing the id for the SpaceCenter.LandingGear
+ * @result {Long} A long value representing the id for the SpaceCenter.Leg
  * @returns {{call :Object, decode: function}}
  */
-module.exports.partGetLandingGear = function partGetLandingGear(part) {
+module.exports.partGetLeg = function partGetLeg(part) {
     let encodedArguments = [
         encoders.uInt64(part)
     ];
     return {
-        call: buildProcedureCall('SpaceCenter', 'Part_get_LandingGear', encodedArguments),
+        call: buildProcedureCall('SpaceCenter', 'Part_get_Leg', encodedArguments),
         decode: decoders.uInt64
     };
 };
 
 /**
  * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.LandingLeg} if the part is a landing leg, otherwise <c>null</c>.
- * @param {Long} part - A long value representing the id for the SpaceCenter.Part
- * @result {Long} A long value representing the id for the SpaceCenter.LandingLeg
- * @returns {{call :Object, decode: function}}
- */
-module.exports.partGetLandingLeg = function partGetLandingLeg(part) {
-    let encodedArguments = [
-        encoders.uInt64(part)
-    ];
-    return {
-        call: buildProcedureCall('SpaceCenter', 'Part_get_LandingLeg', encodedArguments),
-        decode: decoders.uInt64
-    };
-};
-
-/**
- * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.LaunchClamp} if the part is a launch clamp, otherwise <c>null</c>.
+ * @description A {@link T:SpaceCenter.LaunchClamp} if the part is a launch clamp, otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.LaunchClamp
  * @returns {{call :Object, decode: function}}
@@ -9429,7 +12243,7 @@ module.exports.partGetLaunchClamp = function partGetLaunchClamp(part) {
 
 /**
  * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.Light} if the part is a light, otherwise <c>null</c>.
+ * @description A {@link T:SpaceCenter.Light} if the part is a light, otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.Light
  * @returns {{call :Object, decode: function}}
@@ -9446,7 +12260,7 @@ module.exports.partGetLight = function partGetLight(part) {
 
 /**
  * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.Parachute} if the part is a parachute, otherwise <c>null</c>.
+ * @description A {@link T:SpaceCenter.Parachute} if the part is a parachute, otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.Parachute
  * @returns {{call :Object, decode: function}}
@@ -9463,7 +12277,7 @@ module.exports.partGetParachute = function partGetParachute(part) {
 
 /**
  * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.Radiator} if the part is a radiator, otherwise <c>null</c>.
+ * @description A {@link T:SpaceCenter.Radiator} if the part is a radiator, otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.Radiator
  * @returns {{call :Object, decode: function}}
@@ -9480,7 +12294,7 @@ module.exports.partGetRadiator = function partGetRadiator(part) {
 
 /**
  * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.RCS} if the part is an RCS block/thruster, otherwise <c>null</c>.
+ * @description A {@link T:SpaceCenter.RCS} if the part is an RCS block/thruster, otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.RCS
  * @returns {{call :Object, decode: function}}
@@ -9497,7 +12311,7 @@ module.exports.partGetRcs = function partGetRcs(part) {
 
 /**
  * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.ReactionWheel} if the part is a reaction wheel, otherwise <c>null</c>.
+ * @description A {@link T:SpaceCenter.ReactionWheel} if the part is a reaction wheel, otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.ReactionWheel
  * @returns {{call :Object, decode: function}}
@@ -9514,7 +12328,8 @@ module.exports.partGetReactionWheel = function partGetReactionWheel(part) {
 
 /**
  * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.ResourceConverter} if the part is a resource converter, otherwise <c>null</c>.
+ * @description A {@link T:SpaceCenter.ResourceConverter} if the part is a resource converter,
+ * otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.ResourceConverter
  * @returns {{call :Object, decode: function}}
@@ -9531,7 +12346,8 @@ module.exports.partGetResourceConverter = function partGetResourceConverter(part
 
 /**
  * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.ResourceHarvester} if the part is a resource harvester, otherwise <c>null</c>.
+ * @description A {@link T:SpaceCenter.ResourceHarvester} if the part is a resource harvester,
+ * otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.ResourceHarvester
  * @returns {{call :Object, decode: function}}
@@ -9548,7 +12364,7 @@ module.exports.partGetResourceHarvester = function partGetResourceHarvester(part
 
 /**
  * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.Sensor} if the part is a sensor, otherwise <c>null</c>.
+ * @description A {@link T:SpaceCenter.Sensor} if the part is a sensor, otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.Sensor
  * @returns {{call :Object, decode: function}}
@@ -9565,7 +12381,7 @@ module.exports.partGetSensor = function partGetSensor(part) {
 
 /**
  * @augments SpaceCenter
- * @description A {@link T:SpaceCenter.SolarPanel} if the part is a solar panel, otherwise <c>null</c>.
+ * @description A {@link T:SpaceCenter.SolarPanel} if the part is a solar panel, otherwise null.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.SolarPanel
  * @returns {{call :Object, decode: function}}
@@ -9576,6 +12392,23 @@ module.exports.partGetSolarPanel = function partGetSolarPanel(part) {
     ];
     return {
         call: buildProcedureCall('SpaceCenter', 'Part_get_SolarPanel', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description A {@link T:SpaceCenter.Wheel} if the part is a wheel, otherwise null.
+ * @param {Long} part - A long value representing the id for the SpaceCenter.Part
+ * @result {Long} A long value representing the id for the SpaceCenter.Wheel
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.partGetWheel = function partGetWheel(part) {
+    let encodedArguments = [
+        encoders.uInt64(part)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Part_get_Wheel', encodedArguments),
         decode: decoders.uInt64
     };
 };
@@ -9608,7 +12441,8 @@ module.exports.partGetMomentOfInertia = function partGetMomentOfInertia(part) {
 
 /**
  * @augments SpaceCenter
- * @description The inertia tensor of the part in the parts reference frame ({@link T:SpaceCenter.ReferenceFrame}).
+ * @description The inertia tensor of the part in the parts reference frame
+ * ({@link T:SpaceCenter.ReferenceFrame}).
  * Returns the 3x3 matrix as a list of elements, in row-major order.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {number[]}
@@ -9632,10 +12466,14 @@ module.exports.partGetInertiaTensor = function partGetInertiaTensor(part) {
 
 /**
  * @augments SpaceCenter
- * @description The reference frame that is fixed relative to this part, and centered on a fixed position within the part, defined by the parts model.
- * <list type="bullet"><item><description>The origin is at the position of the part, as returned by {@link M:SpaceCenter.Part.Position}.</description></item><item><description>The axes rotate with the part.</description></item><item><description>The x, y and z axis directions depend on the design of the part.</description></item></list><remarks>
- * For docking port parts, this reference frame is not necessarily equivalent to the reference frame
- * for the docking port, returned by {@link M:SpaceCenter.DockingPort.ReferenceFrame}.
+ * @description The reference frame that is fixed relative to this part, and centered on a fixed
+ * position within the part, defined by the parts model.
+ * <list type="bullet"><item><description>The origin is at the position of the part, as returned by
+ * {@link M:SpaceCenter.Part.Position}.</description></item><item><description>The axes rotate with the part.</description></item><item><description>The x, y and z axis directions depend on the design of the part.
+ * </description></item></list><remarks>
+ * For docking port parts, this reference frame is not necessarily equivalent to the
+ * reference frame for the docking port, returned by
+ * {@link M:SpaceCenter.DockingPort.ReferenceFrame}.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.ReferenceFrame
  * @returns {{call :Object, decode: function}}
@@ -9652,10 +12490,14 @@ module.exports.partGetReferenceFrame = function partGetReferenceFrame(part) {
 
 /**
  * @augments SpaceCenter
- * @description The reference frame that is fixed relative to this part, and centered on its center of mass.
- * <list type="bullet"><item><description>The origin is at the center of mass of the part, as returned by {@link M:SpaceCenter.Part.CenterOfMass}.</description></item><item><description>The axes rotate with the part.</description></item><item><description>The x, y and z axis directions depend on the design of the part.</description></item></list><remarks>
- * For docking port parts, this reference frame is not necessarily equivalent to the reference frame
- * for the docking port, returned by {@link M:SpaceCenter.DockingPort.ReferenceFrame}.
+ * @description The reference frame that is fixed relative to this part, and centered on its
+ * center of mass.
+ * <list type="bullet"><item><description>The origin is at the center of mass of the part, as returned by
+ * {@link M:SpaceCenter.Part.CenterOfMass}.</description></item><item><description>The axes rotate with the part.</description></item><item><description>The x, y and z axis directions depend on the design of the part.
+ * </description></item></list><remarks>
+ * For docking port parts, this reference frame is not necessarily equivalent to the
+ * reference frame for the docking port, returned by
+ * {@link M:SpaceCenter.DockingPort.ReferenceFrame}.
  * @param {Long} part - A long value representing the id for the SpaceCenter.Part
  * @result {Long} A long value representing the id for the SpaceCenter.ReferenceFrame
  * @returns {{call :Object, decode: function}}
@@ -9672,7 +12514,7 @@ module.exports.partGetCenterOfMassReferenceFrame = function partGetCenterOfMassR
 
 /**
  * @augments SpaceCenter
- * @description A list of parts whose {@link M:SpaceCenter.Part.Name} is <paramref name="name}.
+ * @description A list of parts whose {@link M:SpaceCenter.Part.Name} is {name}.
  * @param {Long} parts - A long value representing the id for the SpaceCenter.Parts
  * @param {string} name
  * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Part
@@ -9697,7 +12539,7 @@ module.exports.partsWithName = function partsWithName(parts, name) {
 
 /**
  * @augments SpaceCenter
- * @description A list of all parts whose {@link M:SpaceCenter.Part.Title} is <paramref name="title}.
+ * @description A list of all parts whose {@link M:SpaceCenter.Part.Title} is {title}.
  * @param {Long} parts - A long value representing the id for the SpaceCenter.Parts
  * @param {string} title
  * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Part
@@ -9722,7 +12564,7 @@ module.exports.partsWithTitle = function partsWithTitle(parts, title) {
 
 /**
  * @augments SpaceCenter
- * @description A list of all parts whose {@link M:SpaceCenter.Part.Tag} is <paramref name="tag}.
+ * @description A list of all parts whose {@link M:SpaceCenter.Part.Tag} is {tag}.
  * @param {Long} parts - A long value representing the id for the SpaceCenter.Parts
  * @param {string} tag
  * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Part
@@ -9748,7 +12590,7 @@ module.exports.partsWithTag = function partsWithTag(parts, tag) {
 /**
  * @augments SpaceCenter
  * @description A list of all parts that contain a {@link T:SpaceCenter.Module} whose
- * {@link M:SpaceCenter.Module.Name} is <paramref name="moduleName}.
+ * {@link M:SpaceCenter.Module.Name} is {moduleName}.
  * @param {Long} parts - A long value representing the id for the SpaceCenter.Parts
  * @param {string} moduleName
  * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Part
@@ -9773,7 +12615,7 @@ module.exports.partsWithModule = function partsWithModule(parts, moduleName) {
 
 /**
  * @augments SpaceCenter
- * @description A list of all parts that are activated in the given <paramref name="stage}.
+ * @description A list of all parts that are activated in the given {stage}.
  * @param {Long} parts - A long value representing the id for the SpaceCenter.Parts
  * @param {number} stage
  * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Part
@@ -9798,7 +12640,7 @@ module.exports.partsInStage = function partsInStage(parts, stage) {
 
 /**
  * @augments SpaceCenter
- * @description A list of all parts that are decoupled in the given <paramref name="stage}.
+ * @description A list of all parts that are decoupled in the given {stage}.
  * @param {Long} parts - A long value representing the id for the SpaceCenter.Parts
  * @param {number} stage
  * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Part
@@ -9824,7 +12666,7 @@ module.exports.partsInDecoupleStage = function partsInDecoupleStage(parts, stage
 /**
  * @augments SpaceCenter
  * @description A list of modules (combined across all parts in the vessel) whose
- * {@link M:SpaceCenter.Module.Name} is <paramref name="moduleName}.
+ * {@link M:SpaceCenter.Module.Name} is {moduleName}.
  * @param {Long} parts - A long value representing the id for the SpaceCenter.Parts
  * @param {string} moduleName
  * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Module
@@ -9925,6 +12767,29 @@ module.exports.partsSetControlling = function partsSetControlling(parts, value) 
 
 /**
  * @augments SpaceCenter
+ * @description A list of all antennas in the vessel.
+ * @param {Long} parts - A long value representing the id for the SpaceCenter.Parts
+ * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Antenna
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.partsGetAntennas = function partsGetAntennas(parts) {
+    let encodedArguments = [
+        encoders.uInt64(parts)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Parts_get_Antennas', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.List,
+            subTypes: [
+                decoders.uInt64
+            ]
+        }
+    };
+};
+
+/**
+ * @augments SpaceCenter
  * @description A list of all control surfaces in the vessel.
  * @param {Long} parts - A long value representing the id for the SpaceCenter.Parts
  * @result {Long[]} A list of long values representing the ids for the SpaceCenter.ControlSurface
@@ -10018,8 +12883,9 @@ module.exports.partsGetDockingPorts = function partsGetDockingPorts(parts) {
 /**
  * @augments SpaceCenter
  * @description A list of all engines in the vessel.
- *  This includes any part that generates thrust. This covers many different types of engine,
- * including liquid fuel rockets, solid rocket boosters, jet engines and RCS thrusters.
+ *  This includes any part that generates thrust. This covers many different types
+ * of engine, including liquid fuel rockets, solid rocket boosters, jet engines and
+ * RCS thrusters.
  * @param {Long} parts - A long value representing the id for the SpaceCenter.Parts
  * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Engine
  * @returns {{call :Object, decode: function}}
@@ -10111,40 +12977,17 @@ module.exports.partsGetIntakes = function partsGetIntakes(parts) {
 
 /**
  * @augments SpaceCenter
- * @description A list of all landing gear attached to the vessel.
- * @param {Long} parts - A long value representing the id for the SpaceCenter.Parts
- * @result {Long[]} A list of long values representing the ids for the SpaceCenter.LandingGear
- * @returns {{call :Object, decode: function}}
- */
-module.exports.partsGetLandingGear = function partsGetLandingGear(parts) {
-    let encodedArguments = [
-        encoders.uInt64(parts)
-    ];
-    return {
-        call: buildProcedureCall('SpaceCenter', 'Parts_get_LandingGear', encodedArguments),
-        decode: {
-            isCollection: true,
-            decode: proto.List,
-            subTypes: [
-                decoders.uInt64
-            ]
-        }
-    };
-};
-
-/**
- * @augments SpaceCenter
  * @description A list of all landing legs attached to the vessel.
  * @param {Long} parts - A long value representing the id for the SpaceCenter.Parts
- * @result {Long[]} A list of long values representing the ids for the SpaceCenter.LandingLeg
+ * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Leg
  * @returns {{call :Object, decode: function}}
  */
-module.exports.partsGetLandingLegs = function partsGetLandingLegs(parts) {
+module.exports.partsGetLegs = function partsGetLegs(parts) {
     let encodedArguments = [
         encoders.uInt64(parts)
     ];
     return {
-        call: buildProcedureCall('SpaceCenter', 'Parts_get_LandingLegs', encodedArguments),
+        call: buildProcedureCall('SpaceCenter', 'Parts_get_Legs', encodedArguments),
         decode: {
             isCollection: true,
             decode: proto.List,
@@ -10387,6 +13230,29 @@ module.exports.partsGetSolarPanels = function partsGetSolarPanels(parts) {
 
 /**
  * @augments SpaceCenter
+ * @description A list of all wheels in the vessel.
+ * @param {Long} parts - A long value representing the id for the SpaceCenter.Parts
+ * @result {Long[]} A list of long values representing the ids for the SpaceCenter.Wheel
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.partsGetWheels = function partsGetWheels(parts) {
+    let encodedArguments = [
+        encoders.uInt64(parts)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Parts_get_Wheels', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.List,
+            subTypes: [
+                decoders.uInt64
+            ]
+        }
+    };
+};
+
+/**
+ * @augments SpaceCenter
  * @description The name of the propellant.
  * @param {Long} propellant - A long value representing the id for the SpaceCenter.Propellant
  * @result {string}
@@ -10438,7 +13304,8 @@ module.exports.propellantGetCurrentRequirement = function propellantGetCurrentRe
 
 /**
  * @augments SpaceCenter
- * @description The total amount of the underlying resource currently reachable given resource flow rules.
+ * @description The total amount of the underlying resource currently reachable given
+ * resource flow rules.
  * @param {Long} propellant - A long value representing the id for the SpaceCenter.Propellant
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -10455,7 +13322,8 @@ module.exports.propellantGetTotalResourceAvailable = function propellantGetTotal
 
 /**
  * @augments SpaceCenter
- * @description The total vehicle capacity for the underlying propellant resource, restricted by resource flow rules.
+ * @description The total vehicle capacity for the underlying propellant resource,
+ * restricted by resource flow rules.
  * @param {Long} propellant - A long value representing the id for the SpaceCenter.Propellant
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -10472,7 +13340,8 @@ module.exports.propellantGetTotalResourceCapacity = function propellantGetTotalR
 
 /**
  * @augments SpaceCenter
- * @description If this propellant should be ignored when calculating required mass flow given specific impulse.
+ * @description If this propellant should be ignored when calculating required mass flow
+ * given specific impulse.
  * @param {Long} propellant - A long value representing the id for the SpaceCenter.Propellant
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
@@ -10575,9 +13444,9 @@ module.exports.rcsGetPart = function rcsGetPart(rcs) {
 /**
  * @augments SpaceCenter
  * @description Whether the RCS thrusters are active.
- * An RCS thruster is inactive if the RCS action group is disabled ({@link M:SpaceCenter.Control.RCS}),
- * the RCS thruster itself is not enabled ({@link M:SpaceCenter.RCS.Enabled}) or
- * it is covered by a fairing ({@link M:SpaceCenter.Part.Shielded}).
+ * An RCS thruster is inactive if the RCS action group is disabled
+ * ({@link M:SpaceCenter.Control.RCS}), the RCS thruster itself is not enabled
+ * ({@link M:SpaceCenter.RCS.Enabled}) or it is covered by a fairing ({@link M:SpaceCenter.Part.Shielded}).
  * @param {Long} rcs - A long value representing the id for the SpaceCenter.RCS
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
@@ -10846,9 +13715,10 @@ module.exports.rcsSetRightEnabled = function rcsSetRightEnabled(rcs, value) {
 
 /**
  * @augments SpaceCenter
- * @description The available torque in the pitch, roll and yaw axes of the vessel, in Newton meters.
- * These axes correspond to the coordinate axes of the {@link M:SpaceCenter.Vessel.ReferenceFrame}.
- * Returns zero if the RCS is inactive.
+ * @description The available torque, in Newton meters, that can be produced by this RCS,
+ * in the positive and negative pitch, roll and yaw axes of the vessel. These axes
+ * correspond to the coordinate axes of the {@link M:SpaceCenter.Vessel.ReferenceFrame}.
+ * Returns zero if RCS is disable.
  * @param {Long} rcs - A long value representing the id for the SpaceCenter.RCS
  * @result {{{number, number, number}, {number, number, number}}}
  * @returns {{call :Object, decode: function}}
@@ -10888,7 +13758,8 @@ module.exports.rcsGetAvailableTorque = function rcsGetAvailableTorque(rcs) {
 
 /**
  * @augments SpaceCenter
- * @description The maximum amount of thrust that can be produced by the RCS thrusters when active, in Newtons.
+ * @description The maximum amount of thrust that can be produced by the RCS thrusters when active,
+ * in Newtons.
  * @param {Long} rcs - A long value representing the id for the SpaceCenter.RCS
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -10905,7 +13776,8 @@ module.exports.rcsGetMaxThrust = function rcsGetMaxThrust(rcs) {
 
 /**
  * @augments SpaceCenter
- * @description The maximum amount of thrust that can be produced by the RCS thrusters when active in a vacuum, in Newtons.
+ * @description The maximum amount of thrust that can be produced by the RCS thrusters when active
+ * in a vacuum, in Newtons.
  * @param {Long} rcs - A long value representing the id for the SpaceCenter.RCS
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -11097,8 +13969,8 @@ module.exports.radiatorGetDeployable = function radiatorGetDeployable(radiator) 
 
 /**
  * @augments SpaceCenter
- * @description For a deployable radiator, <c>true</c> if the radiator is extended.
- * If the radiator is not deployable, this is always <c>true</c>.
+ * @description For a deployable radiator, true if the radiator is extended.
+ * If the radiator is not deployable, this is always true.
  * @param {Long} radiator - A long value representing the id for the SpaceCenter.Radiator
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
@@ -11115,8 +13987,8 @@ module.exports.radiatorGetDeployed = function radiatorGetDeployed(radiator) {
 
 /**
  * @augments SpaceCenter
- * @description For a deployable radiator, <c>true</c> if the radiator is extended.
- * If the radiator is not deployable, this is always <c>true</c>.
+ * @description For a deployable radiator, true if the radiator is extended.
+ * If the radiator is not deployable, this is always true.
  * @param {Long} radiator - A long value representing the id for the SpaceCenter.Radiator
  * @param {boolean} value
  * @result {void}
@@ -11229,8 +14101,9 @@ module.exports.reactionWheelGetBroken = function reactionWheelGetBroken(reaction
 
 /**
  * @augments SpaceCenter
- * @description The available torque in the pitch, roll and yaw axes of the vessel, in Newton meters.
- * These axes correspond to the coordinate axes of the {@link M:SpaceCenter.Vessel.ReferenceFrame}.
+ * @description The available torque, in Newton meters, that can be produced by this reaction wheel,
+ * in the positive and negative pitch, roll and yaw axes of the vessel. These axes
+ * correspond to the coordinate axes of the {@link M:SpaceCenter.Vessel.ReferenceFrame}.
  * Returns zero if the reaction wheel is inactive or broken.
  * @param {Long} reactionWheel - A long value representing the id for the SpaceCenter.ReactionWheel
  * @result {{{number, number, number}, {number, number, number}}}
@@ -11271,8 +14144,8 @@ module.exports.reactionWheelGetAvailableTorque = function reactionWheelGetAvaila
 
 /**
  * @augments SpaceCenter
- * @description The maximum torque the reaction wheel can provide, is it active,
- * in the pitch, roll and yaw axes of the vessel, in Newton meters.
+ * @description The maximum torque, in Newton meters, that can be produced by this reaction wheel,
+ * when it is active, in the positive and negative pitch, roll and yaw axes of the vessel.
  * These axes correspond to the coordinate axes of the {@link M:SpaceCenter.Vessel.ReferenceFrame}.
  * @param {Long} reactionWheel - A long value representing the id for the SpaceCenter.ReactionWheel
  * @result {{{number, number, number}, {number, number, number}}}
@@ -11519,6 +14392,57 @@ module.exports.resourceConverterGetCount = function resourceConverterGetCount(re
 
 /**
  * @augments SpaceCenter
+ * @description The thermal efficiency of the converter, as a percentage of its maximum.
+ * @param {Long} resourceConverter - A long value representing the id for the SpaceCenter.ResourceConverter
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.resourceConverterGetThermalEfficiency = function resourceConverterGetThermalEfficiency(resourceConverter) {
+    let encodedArguments = [
+        encoders.uInt64(resourceConverter)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ResourceConverter_get_ThermalEfficiency', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The core temperature of the converter, in Kelvin.
+ * @param {Long} resourceConverter - A long value representing the id for the SpaceCenter.ResourceConverter
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.resourceConverterGetCoreTemperature = function resourceConverterGetCoreTemperature(resourceConverter) {
+    let encodedArguments = [
+        encoders.uInt64(resourceConverter)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ResourceConverter_get_CoreTemperature', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The core temperature at which the converter will operate with peak efficiency, in Kelvin.
+ * @param {Long} resourceConverter - A long value representing the id for the SpaceCenter.ResourceConverter
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.resourceConverterGetOptimumCoreTemperature = function resourceConverterGetOptimumCoreTemperature(resourceConverter) {
+    let encodedArguments = [
+        encoders.uInt64(resourceConverter)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'ResourceConverter_get_OptimumCoreTemperature', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
  * @description The part object for this harvester.
  * @param {Long} resourceHarvester - A long value representing the id for the SpaceCenter.ResourceHarvester
  * @result {Long} A long value representing the id for the SpaceCenter.Part
@@ -11750,7 +14674,8 @@ module.exports.scienceDataGetTransmitValue = function scienceDataGetTransmitValu
 
 /**
  * @augments SpaceCenter
- * @description Amount of science already earned from this subject, not updated until after transmission/recovery.
+ * @description Amount of science already earned from this subject, not updated until after
+ * transmission/recovery.
  * @param {Long} scienceSubject - A long value representing the id for the SpaceCenter.ScienceSubject
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -11818,7 +14743,8 @@ module.exports.scienceSubjectGetDataScale = function scienceSubjectGetDataScale(
 
 /**
  * @augments SpaceCenter
- * @description Diminishing value multiplier for decreasing the science value returned from repeated experiments.
+ * @description Diminishing value multiplier for decreasing the science value returned from repeated
+ * experiments.
  * @param {Long} scienceSubject - A long value representing the id for the SpaceCenter.ScienceSubject
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -11956,6 +14882,23 @@ module.exports.solarPanelGetPart = function solarPanelGetPart(solarPanel) {
 
 /**
  * @augments SpaceCenter
+ * @description Whether the solar panel is deployable.
+ * @param {Long} solarPanel - A long value representing the id for the SpaceCenter.SolarPanel
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.solarPanelGetDeployable = function solarPanelGetDeployable(solarPanel) {
+    let encodedArguments = [
+        encoders.uInt64(solarPanel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'SolarPanel_get_Deployable', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
  * @description Whether the solar panel is extended.
  * @param {Long} solarPanel - A long value representing the id for the SpaceCenter.SolarPanel
  * @result {boolean}
@@ -12053,6 +14996,9 @@ module.exports.solarPanelGetSunExposure = function solarPanelGetSunExposure(sola
  * @augments SpaceCenter
  * @description The position at which the thruster generates thrust, in the given reference frame.
  * For gimballed engines, this takes into account the current rotation of the gimbal.
+ * Returns: The position as a vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * position vector is in.</param>
  * @param {Long} thruster - A long value representing the id for the SpaceCenter.Thruster
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -12082,6 +15028,9 @@ module.exports.thrusterThrustPosition = function thrusterThrustPosition(thruster
  * @description The direction of the force generated by the thruster, in the given reference frame.
  * This is opposite to the direction in which the thruster expels propellant.
  * For gimballed engines, this takes into account the current rotation of the gimbal.
+ * Returns: The direction as a unit vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * direction is in.</param>
  * @param {Long} thruster - A long value representing the id for the SpaceCenter.Thruster
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -12110,7 +15059,9 @@ module.exports.thrusterThrustDirection = function thrusterThrustDirection(thrust
  * @augments SpaceCenter
  * @description The position at which the thruster generates thrust, when the engine is in its
  * initial position (no gimballing), in the given reference frame.
- *
+ * Returns: The position as a vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * position vector is in.</param>
  *  This position can move when the gimbal rotates. This is because the thrust position and
  * gimbal position are not necessarily the same.
  * @param {Long} thruster - A long value representing the id for the SpaceCenter.Thruster
@@ -12142,6 +15093,9 @@ module.exports.thrusterInitialThrustPosition = function thrusterInitialThrustPos
  * @description The direction of the force generated by the thruster, when the engine is in its
  * initial position (no gimballing), in the given reference frame.
  * This is opposite to the direction in which the thruster expels propellant.
+ * Returns: The direction as a unit vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * direction is in.</param>
  * @param {Long} thruster - A long value representing the id for the SpaceCenter.Thruster
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -12169,6 +15123,9 @@ module.exports.thrusterInitialThrustDirection = function thrusterInitialThrustDi
 /**
  * @augments SpaceCenter
  * @description Position around which the gimbal pivots.
+ * Returns: The position as a vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * position vector is in.</param>
  * @param {Long} thruster - A long value representing the id for the SpaceCenter.Thruster
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -12216,11 +15173,12 @@ module.exports.thrusterGetPart = function thrusterGetPart(thruster) {
  * its thrust direction ({@link M:SpaceCenter.Thruster.ThrustDirection}).
  * For gimballed engines, this takes into account the current rotation of the gimbal.
  * <list type="bullet"><item><description>
- * The origin is at the position of thrust for this thruster ({@link M:SpaceCenter.Thruster.ThrustPosition}).
- * </description></item><item><description>
+ * The origin is at the position of thrust for this thruster
+ * ({@link M:SpaceCenter.Thruster.ThrustPosition}).</description></item><item><description>
  * The axes rotate with the thrust direction.
  * This is the direction in which the thruster expels propellant, including any gimballing.
- * </description></item><item><description>The y-axis points along the thrust direction.</description></item><item><description>The x-axis and z-axis are perpendicular to the thrust direction.</description></item></list>
+ * </description></item><item><description>The y-axis points along the thrust direction.</description></item><item><description>The x-axis and z-axis are perpendicular to the thrust direction.
+ * </description></item></list>
  * @param {Long} thruster - A long value representing the id for the SpaceCenter.Thruster
  * @result {Long} A long value representing the id for the SpaceCenter.ReferenceFrame
  * @returns {{call :Object, decode: function}}
@@ -12254,7 +15212,7 @@ module.exports.thrusterGetGimballed = function thrusterGetGimballed(thruster) {
 
 /**
  * @augments SpaceCenter
- * @description The current gimbal angle in the pitch, roll and yaw axes.
+ * @description The current gimbal angle in the pitch, roll and yaw axes, in degrees.
  * @param {Long} thruster - A long value representing the id for the SpaceCenter.Thruster
  * @result {{number, number, number}}
  * @returns {{call :Object, decode: function}}
@@ -12279,12 +15237,795 @@ module.exports.thrusterGetGimbalAngle = function thrusterGetGimbalAngle(thruster
 
 /**
  * @augments SpaceCenter
- * @description Create a relative reference frame.
+ * @description The part object for this wheel.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {Long} A long value representing the id for the SpaceCenter.Part
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetPart = function wheelGetPart(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_Part', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The current state of the wheel.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {Long} A long value representing the id for the SpaceCenter.WheelState
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetState = function wheelGetState(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_State', encodedArguments),
+        decode: decoders.enum({
+            0: 'Deployed',
+            1: 'Retracted',
+            2: 'Deploying',
+            3: 'Retracting',
+            4: 'Broken'
+        })
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Radius of the wheel, in meters.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetRadius = function wheelGetRadius(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_Radius', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the wheel is touching the ground.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetGrounded = function wheelGetGrounded(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_Grounded', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the wheel has brakes.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetHasBrakes = function wheelGetHasBrakes(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_HasBrakes', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The braking force, as a percentage of maximum, when the brakes are applied.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetBrakes = function wheelGetBrakes(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_Brakes', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The braking force, as a percentage of maximum, when the brakes are applied.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @param {number} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.wheelSetBrakes = function wheelSetBrakes(wheel, value) {
+    let encodedArguments = [
+        encoders.uInt64(wheel),
+        encoders.float(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_set_Brakes', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether automatic friction control is enabled.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetAutoFrictionControl = function wheelGetAutoFrictionControl(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_AutoFrictionControl', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether automatic friction control is enabled.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.wheelSetAutoFrictionControl = function wheelSetAutoFrictionControl(wheel, value) {
+    let encodedArguments = [
+        encoders.uInt64(wheel),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_set_AutoFrictionControl', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Manual friction control value. Only has an effect if automatic friction control is disabled.
+ * A value between 0 and 5 inclusive.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetManualFrictionControl = function wheelGetManualFrictionControl(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_ManualFrictionControl', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Manual friction control value. Only has an effect if automatic friction control is disabled.
+ * A value between 0 and 5 inclusive.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @param {number} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.wheelSetManualFrictionControl = function wheelSetManualFrictionControl(wheel, value) {
+    let encodedArguments = [
+        encoders.uInt64(wheel),
+        encoders.float(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_set_ManualFrictionControl', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the wheel is deployable.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetDeployable = function wheelGetDeployable(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_Deployable', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the wheel is deployed.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetDeployed = function wheelGetDeployed(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_Deployed', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the wheel is deployed.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.wheelSetDeployed = function wheelSetDeployed(wheel, value) {
+    let encodedArguments = [
+        encoders.uInt64(wheel),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_set_Deployed', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the wheel is powered by a motor.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetPowered = function wheelGetPowered(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_Powered', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the motor is enabled.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetMotorEnabled = function wheelGetMotorEnabled(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_MotorEnabled', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the motor is enabled.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.wheelSetMotorEnabled = function wheelSetMotorEnabled(wheel, value) {
+    let encodedArguments = [
+        encoders.uInt64(wheel),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_set_MotorEnabled', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the direction of the motor is inverted.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetMotorInverted = function wheelGetMotorInverted(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_MotorInverted', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the direction of the motor is inverted.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.wheelSetMotorInverted = function wheelSetMotorInverted(wheel, value) {
+    let encodedArguments = [
+        encoders.uInt64(wheel),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_set_MotorInverted', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the direction of the motor is inverted.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {Long} A long value representing the id for the SpaceCenter.MotorState
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetMotorState = function wheelGetMotorState(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_MotorState', encodedArguments),
+        decode: decoders.enum({
+            0: 'Idle',
+            1: 'Running',
+            2: 'Disabled',
+            3: 'Inoperable',
+            4: 'NotEnoughResources'
+        })
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The output of the motor. This is the torque currently being generated, in Newton meters.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetMotorOutput = function wheelGetMotorOutput(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_MotorOutput', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether automatic traction control is enabled.
+ * A wheel only has traction control if it is powered.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetTractionControlEnabled = function wheelGetTractionControlEnabled(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_TractionControlEnabled', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether automatic traction control is enabled.
+ * A wheel only has traction control if it is powered.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.wheelSetTractionControlEnabled = function wheelSetTractionControlEnabled(wheel, value) {
+    let encodedArguments = [
+        encoders.uInt64(wheel),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_set_TractionControlEnabled', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Setting for the traction control.
+ * Only takes effect if the wheel has automatic traction control enabled.
+ * A value between 0 and 5 inclusive.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetTractionControl = function wheelGetTractionControl(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_TractionControl', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Setting for the traction control.
+ * Only takes effect if the wheel has automatic traction control enabled.
+ * A value between 0 and 5 inclusive.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @param {number} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.wheelSetTractionControl = function wheelSetTractionControl(wheel, value) {
+    let encodedArguments = [
+        encoders.uInt64(wheel),
+        encoders.float(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_set_TractionControl', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Manual setting for the motor limiter.
+ * Only takes effect if the wheel has automatic traction control disabled.
+ * A value between 0 and 100 inclusive.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetDriveLimiter = function wheelGetDriveLimiter(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_DriveLimiter', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Manual setting for the motor limiter.
+ * Only takes effect if the wheel has automatic traction control disabled.
+ * A value between 0 and 100 inclusive.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @param {number} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.wheelSetDriveLimiter = function wheelSetDriveLimiter(wheel, value) {
+    let encodedArguments = [
+        encoders.uInt64(wheel),
+        encoders.float(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_set_DriveLimiter', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the wheel has steering.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetSteerable = function wheelGetSteerable(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_Steerable', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the wheel steering is enabled.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetSteeringEnabled = function wheelGetSteeringEnabled(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_SteeringEnabled', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the wheel steering is enabled.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.wheelSetSteeringEnabled = function wheelSetSteeringEnabled(wheel, value) {
+    let encodedArguments = [
+        encoders.uInt64(wheel),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_set_SteeringEnabled', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the wheel steering is inverted.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetSteeringInverted = function wheelGetSteeringInverted(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_SteeringInverted', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the wheel steering is inverted.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @param {boolean} value
+ * @result {void}
+ * @returns {void}
+ */
+module.exports.wheelSetSteeringInverted = function wheelSetSteeringInverted(wheel, value) {
+    let encodedArguments = [
+        encoders.uInt64(wheel),
+        encoders.bool(value)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_set_SteeringInverted', encodedArguments),
+        decode: null
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the wheel has suspension.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetHasSuspension = function wheelGetHasSuspension(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_HasSuspension', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Suspension spring strength, as set in the editor.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetSuspensionSpringStrength = function wheelGetSuspensionSpringStrength(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_SuspensionSpringStrength', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Suspension damper strength, as set in the editor.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetSuspensionDamperStrength = function wheelGetSuspensionDamperStrength(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_SuspensionDamperStrength', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the wheel is broken.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetBroken = function wheelGetBroken(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_Broken', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Whether the wheel is repairable.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {boolean}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetRepairable = function wheelGetRepairable(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_Repairable', encodedArguments),
+        decode: decoders.bool
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Current stress on the wheel.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetStress = function wheelGetStress(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_Stress', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Stress tolerance of the wheel.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetStressTolerance = function wheelGetStressTolerance(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_StressTolerance', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Current stress on the wheel as a percentage of its stress tolerance.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetStressPercentage = function wheelGetStressPercentage(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_StressPercentage', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Current deflection of the wheel.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetDeflection = function wheelGetDeflection(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_Deflection', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Current slip of the wheel.
+ * @param {Long} wheel - A long value representing the id for the SpaceCenter.Wheel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.wheelGetSlip = function wheelGetSlip(wheel) {
+    let encodedArguments = [
+        encoders.uInt64(wheel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Wheel_get_Slip', encodedArguments),
+        decode: decoders.float
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Create a relative reference frame. This is a custom reference frame
+ * whose components offset the components of a parent reference frame.
+ * <param name="referenceFrame">The parent reference frame on which to
+ * base this reference frame.</param>
+ * <param name="position">The offset of the position of the origin,
+ * as a position vector. Defaults to <math>(0, 0, 0)</math></param>
+ * <param name="rotation">The rotation to apply to the parent frames rotation,
+ * as a quaternion of the form <math>(x, y, z, w)</math>.
+ * Defaults to <math>(0, 0, 0, 1)</math> (i.e. no rotation)</param>
+ * <param name="velocity">The linear velocity to offset the parent frame by,
+ * as a vector pointing in the direction of travel, whose magnitude is the speed in
+ * meters per second. Defaults to <math>(0, 0, 0)</math>.</param>
+ * <param name="angularVelocity">The angular velocity to offset the parent frame by,
+ * as a vector. This vector points in the direction of the axis of rotation,
+ * and its magnitude is the speed of the rotation in radians per second.
+ * Defaults to <math>(0, 0, 0)</math>.</param>
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
- * @param {{number, number, number}} position - The offset of the position of the origin.
- * @param {{number, number, number, number}} rotation - The rotation to apply to the parent frames rotation, as a quaternion. Defaults to zero.
- * @param {{number, number, number}} velocity - The linear velocity to offset the parent frame by. Defaults to zero.
- * @param {{number, number, number}} angularVelocity - The angular velocity to offset the parent frame by. Defaults to zero.
+ * @param {{number, number, number}} position - The offset of the position of the origin,
+as a position vector. Defaults to <math>(0, 0, 0)</math>
+ * @param {{number, number, number, number}} rotation - The rotation to apply to the parent frames rotation,
+as a quaternion of the form <math>(x, y, z, w)</math>.
+Defaults to <math>(0, 0, 0, 1)</math> (i.e. no rotation)
+ * @param {{number, number, number}} velocity - The linear velocity to offset the parent frame by,
+as a vector pointing in the direction of travel, whose magnitude is the speed in
+meters per second. Defaults to <math>(0, 0, 0)</math>.
+ * @param {{number, number, number}} angularVelocity - The angular velocity to offset the parent frame by,
+as a vector. This vector points in the direction of the axis of rotation,
+and its magnitude is the speed of the rotation in radians per second.
+Defaults to <math>(0, 0, 0)</math>.
  * @result {Long} A long value representing the id for the SpaceCenter.ReferenceFrame
  * @returns {{call :Object, decode: function}}
  */
@@ -12304,14 +16045,17 @@ module.exports.referenceFrameStaticCreateRelative = function referenceFrameStati
 
 /**
  * @augments SpaceCenter
- * @description Create a hybrid reference frame, which is a custom reference frame
- * whose components are inherited from other reference frames.
- *
- *
- *
- *
- *  The <paramref name="position} is required but all other reference frames are optional.
- * If omitted, they are set to the <paramref name="position} reference frame.
+ * @description Create a hybrid reference frame. This is a custom reference frame
+ * whose components inherited from other reference frames.
+ * 
+ * 
+ * <param name="velocity">The reference frame providing the linear velocity of the frame.
+ * </param>
+ * <param name="angularVelocity">The reference frame providing the angular velocity
+ * of the frame.</param>
+ *  The {position} reference frame is required but all other
+ * reference frames are optional. If omitted, they are set to the
+ * {position} reference frame.
  * @param {Long} position - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @param {Long} rotation - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @param {Long} velocity - A long value representing the id for the SpaceCenter.ReferenceFrame
@@ -12477,9 +16221,10 @@ module.exports.resourceSetEnabled = function resourceSetEnabled(resource, value)
 
 /**
  * @augments SpaceCenter
- * @description Start transferring a resource transfer between a pair of parts. The transfer will move at most
- * <paramref name="maxAmount} units of the resource, depending on how much of the resource is
- * available in the source part and how much storage is available in the destination part.
+ * @description Start transferring a resource transfer between a pair of parts. The transfer will move
+ * at most {maxAmount} units of the resource, depending on how much of
+ * the resource is available in the source part and how much storage is available in the
+ * destination part.
  * Use {@link M:SpaceCenter.ResourceTransfer.Complete} to check if the transfer is complete.
  * Use {@link M:SpaceCenter.ResourceTransfer.Amount} to see how much of the resource has been transferred.
  * @param {Long} fromPart - A long value representing the id for the SpaceCenter.Part
@@ -12620,7 +16365,7 @@ module.exports.resourcesAmount = function resourcesAmount(resources, name) {
 
 /**
  * @augments SpaceCenter
- * @description Returns the density of a resource, in kg/l.
+ * @description Returns the density of a resource, in <math>kg/l</math>.
  * @param {string} name - The name of the resource.
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -12706,7 +16451,8 @@ module.exports.resourcesGetNames = function resourcesGetNames(resources) {
 /**
  * @augments SpaceCenter
  * @description Whether use of all the resources are enabled.
- *  This is true if all of the resources are enabled. If any of the resources are not enabled, this is false.
+ *  This is true if all of the resources are enabled.
+ * If any of the resources are not enabled, this is false.
  * @param {Long} resources - A long value representing the id for the SpaceCenter.Resources
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
@@ -12724,7 +16470,8 @@ module.exports.resourcesGetEnabled = function resourcesGetEnabled(resources) {
 /**
  * @augments SpaceCenter
  * @description Whether use of all the resources are enabled.
- *  This is true if all of the resources are enabled. If any of the resources are not enabled, this is false.
+ *  This is true if all of the resources are enabled.
+ * If any of the resources are not enabled, this is false.
  * @param {Long} resources - A long value representing the id for the SpaceCenter.Resources
  * @param {boolean} value
  * @result {void}
@@ -12763,7 +16510,8 @@ module.exports.vesselRecover = function vesselRecover(vessel) {
  * @description Returns a {@link T:SpaceCenter.Flight} object that can be used to get flight
  * telemetry for the vessel, in the specified reference frame.
  * <param name="referenceFrame">
- * Reference frame. Defaults to the vessel's surface reference frame ({@link M:SpaceCenter.Vessel.SurfaceReferenceFrame}).
+ * Reference frame. Defaults to the vessel's surface reference frame
+ * ({@link M:SpaceCenter.Vessel.SurfaceReferenceFrame}).
  * </param>
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
@@ -12784,16 +16532,16 @@ module.exports.vesselFlight = function vesselFlight(vessel, referenceFrame) {
 /**
  * @augments SpaceCenter
  * @description Returns a {@link T:SpaceCenter.Resources} object, that can used to get
- * information about resources stored in a given <paramref name="stage}.
- *
- * <param name="cumulative">When <c>false</c>, returns the resources for parts
- * decoupled in just the given stage. When <c>true</c> returns the resources decoupled in
+ * information about resources stored in a given {stage}.
+ * 
+ * <param name="cumulative">When false, returns the resources for parts
+ * decoupled in just the given stage. When true returns the resources decoupled in
  * the given stage and all subsequent stages combined.</param>
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @param {number} stage - Get resources for parts that are decoupled in this stage.
  * @param {boolean} cumulative - When <c>false</c>, returns the resources for parts
- decoupled in just the given stage. When <c>true</c> returns the resources decoupled in
- the given stage and all subsequent stages combined.
+decoupled in just the given stage. When <c>true</c> returns the resources decoupled in
+the given stage and all subsequent stages combined.
  * @result {Long} A long value representing the id for the SpaceCenter.Resources
  * @returns {{call :Object, decode: function}}
  */
@@ -12811,7 +16559,10 @@ module.exports.vesselResourcesInDecoupleStage = function vesselResourcesInDecoup
 
 /**
  * @augments SpaceCenter
- * @description Returns the position vector of the center of mass of the vessel in the given reference frame.
+ * @description The position of the center of mass of the vessel, in the given reference frame.
+ * Returns: The position as a vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * position vector is in.</param>
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -12839,7 +16590,10 @@ module.exports.vesselPosition = function vesselPosition(vessel, referenceFrame) 
 /**
  * @augments SpaceCenter
  * @description The axis-aligned bounding box of the vessel in the given reference frame.
- * Returns the minimum and maximum vertices of the box.
+ * Returns: The positions of the minimum and maximum vertices of the box,
+ * as position vectors.
+ * <param name="referenceFrame">The reference frame that the returned
+ * position vectors are in.</param>
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{{number, number, number}, {number, number, number}}}
@@ -12881,7 +16635,11 @@ module.exports.vesselBoundingBox = function vesselBoundingBox(vessel, referenceF
 
 /**
  * @augments SpaceCenter
- * @description Returns the velocity vector of the center of mass of the vessel in the given reference frame.
+ * @description The velocity of the center of mass of the vessel, in the given reference frame.
+ * Returns: The velocity as a vector. The vector points in the direction of travel,
+ * and its magnitude is the speed of the body in meters per second.
+ * <param name="referenceFrame">The reference frame that the returned
+ * velocity vector is in.</param>
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -12908,7 +16666,10 @@ module.exports.vesselVelocity = function vesselVelocity(vessel, referenceFrame) 
 
 /**
  * @augments SpaceCenter
- * @description Returns the rotation of the center of mass of the vessel in the given reference frame.
+ * @description The rotation of the vessel, in the given reference frame.
+ * Returns: The rotation as a quaternion of the form <math>(x, y, z, w)</math>.
+ * <param name="referenceFrame">The reference frame that the returned
+ * rotation is in.</param>
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number, number}}
@@ -12936,7 +16697,10 @@ module.exports.vesselRotation = function vesselRotation(vessel, referenceFrame) 
 
 /**
  * @augments SpaceCenter
- * @description Returns the direction in which the vessel is pointing, as a unit vector, in the given reference frame.
+ * @description The direction in which the vessel is pointing, in the given reference frame.
+ * Returns: The direction as a unit vector.
+ * <param name="referenceFrame">The reference frame that the returned
+ * direction is in.</param>
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -12963,9 +16727,12 @@ module.exports.vesselDirection = function vesselDirection(vessel, referenceFrame
 
 /**
  * @augments SpaceCenter
- * @description Returns the angular velocity of the vessel in the given reference frame. The magnitude of the returned
- * vector is the rotational speed in radians per second, and the direction of the vector indicates the
- * axis of rotation (using the right hand rule).
+ * @description The angular velocity of the vessel, in the given reference frame.
+ * Returns: The angular velocity as a vector. The magnitude of the vector is the rotational
+ * speed of the vessel, in radians per second. The direction of the vector indicates the
+ * axis of rotation, using the right-hand rule.
+ * <param name="referenceFrame">The reference frame the returned
+ * angular velocity is in.</param>
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @param {Long} referenceFrame - A long value representing the id for the SpaceCenter.ReferenceFrame
  * @result {{number, number, number}}
@@ -13040,13 +16807,15 @@ module.exports.vesselGetType = function vesselGetType(vessel) {
     return {
         call: buildProcedureCall('SpaceCenter', 'Vessel_get_Type', encodedArguments),
         decode: decoders.enum({
-            0: 'Ship',
-            1: 'Station',
+            0: 'Base',
+            1: 'Debris',
             2: 'Lander',
-            3: 'Probe',
-            4: 'Rover',
-            5: 'Base',
-            6: 'Debris'
+            3: 'Plane',
+            4: 'Probe',
+            5: 'Relay',
+            6: 'Rover',
+            7: 'Ship',
+            8: 'Station'
         })
     };
 };
@@ -13063,13 +16832,15 @@ module.exports.vesselSetType = function vesselSetType(vessel, value) {
     let encodedArguments = [
         encoders.uInt64(vessel),
         encoders.enum({
-            0: 'Ship',
-            1: 'Station',
+            0: 'Base',
+            1: 'Debris',
             2: 'Lander',
-            3: 'Probe',
-            4: 'Rover',
-            5: 'Base',
-            6: 'Debris'
+            3: 'Plane',
+            4: 'Probe',
+            5: 'Relay',
+            6: 'Rover',
+            7: 'Ship',
+            8: 'Station'
         })(value)
     ];
     return {
@@ -13193,6 +16964,24 @@ module.exports.vesselGetControl = function vesselGetControl(vessel) {
 
 /**
  * @augments SpaceCenter
+ * @description Returns a {@link T:SpaceCenter.Comms} object that can be used to interact
+ * with CommNet for this vessel.
+ * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
+ * @result {Long} A long value representing the id for the SpaceCenter.Comms
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.vesselGetComms = function vesselGetComms(vessel) {
+    let encodedArguments = [
+        encoders.uInt64(vessel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Vessel_get_Comms', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments SpaceCenter
  * @description An {@link T:SpaceCenter.AutoPilot} object, that can be used to perform
  * simple auto-piloting of the vessel.
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
@@ -13206,6 +16995,63 @@ module.exports.vesselGetAutoPilot = function vesselGetAutoPilot(vessel) {
     return {
         call: buildProcedureCall('SpaceCenter', 'Vessel_get_AutoPilot', encodedArguments),
         decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The number of crew that can occupy the vessel.
+ * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.vesselGetCrewCapacity = function vesselGetCrewCapacity(vessel) {
+    let encodedArguments = [
+        encoders.uInt64(vessel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Vessel_get_CrewCapacity', encodedArguments),
+        decode: decoders.sInt32
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The number of crew that are occupying the vessel.
+ * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
+ * @result {number}
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.vesselGetCrewCount = function vesselGetCrewCount(vessel) {
+    let encodedArguments = [
+        encoders.uInt64(vessel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Vessel_get_CrewCount', encodedArguments),
+        decode: decoders.sInt32
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description The crew in the vessel.
+ * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
+ * @result {Long[]} A list of long values representing the ids for the SpaceCenter.CrewMember
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.vesselGetCrew = function vesselGetCrew(vessel) {
+    let encodedArguments = [
+        encoders.uInt64(vessel)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'Vessel_get_Crew', encodedArguments),
+        decode: {
+            isCollection: true,
+            decode: proto.List,
+            subTypes: [
+                decoders.uInt64
+            ]
+        }
     };
 };
 
@@ -13357,7 +17203,7 @@ module.exports.vesselGetMaxVacuumThrust = function vesselGetMaxVacuumThrust(vess
 /**
  * @augments SpaceCenter
  * @description The combined specific impulse of all active engines, in seconds. This is computed using the formula
- * <a href="http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse#Multiple_engines">described here</a>.
+ * <a href="https://wiki.kerbalspaceprogram.com/wiki/Specific_impulse#Multiple_engines">described here</a>.
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -13375,7 +17221,7 @@ module.exports.vesselGetSpecificImpulse = function vesselGetSpecificImpulse(vess
 /**
  * @augments SpaceCenter
  * @description The combined vacuum specific impulse of all active engines, in seconds. This is computed using the formula
- * <a href="http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse#Multiple_engines">described here</a>.
+ * <a href="https://wiki.kerbalspaceprogram.com/wiki/Specific_impulse#Multiple_engines">described here</a>.
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -13394,7 +17240,7 @@ module.exports.vesselGetVacuumSpecificImpulse = function vesselGetVacuumSpecific
  * @augments SpaceCenter
  * @description The combined specific impulse of all active engines at sea level on Kerbin, in seconds.
  * This is computed using the formula
- * <a href="http://wiki.kerbalspaceprogram.com/wiki/Specific_impulse#Multiple_engines">described here</a>.
+ * <a href="https://wiki.kerbalspaceprogram.com/wiki/Specific_impulse#Multiple_engines">described here</a>.
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -13412,7 +17258,8 @@ module.exports.vesselGetKerbinSeaLevelSpecificImpulse = function vesselGetKerbin
 /**
  * @augments SpaceCenter
  * @description The moment of inertia of the vessel around its center of mass in <math>kg.m^2</math>.
- * The inertia values are around the pitch, roll and yaw directions respectively.
+ * The inertia values in the returned 3-tuple are around the
+ * pitch, roll and yaw directions respectively.
  * This corresponds to the vessels reference frame ({@link T:SpaceCenter.ReferenceFrame}).
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @result {{number, number, number}}
@@ -13438,7 +17285,8 @@ module.exports.vesselGetMomentOfInertia = function vesselGetMomentOfInertia(vess
 
 /**
  * @augments SpaceCenter
- * @description The inertia tensor of the vessel around its center of mass, in the vessels reference frame ({@link T:SpaceCenter.ReferenceFrame}).
+ * @description The inertia tensor of the vessel around its center of mass,
+ * in the vessels reference frame ({@link T:SpaceCenter.ReferenceFrame}).
  * Returns the 3x3 matrix as a list of elements, in row-major order.
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @result {number[]}
@@ -13462,8 +17310,8 @@ module.exports.vesselGetInertiaTensor = function vesselGetInertiaTensor(vessel) 
 
 /**
  * @augments SpaceCenter
- * @description The maximum torque that the vessel generate. Includes contributions from reaction wheels,
- * RCS, gimballed engines and aerodynamic control surfaces.
+ * @description The maximum torque that the vessel generates. Includes contributions from
+ * reaction wheels, RCS, gimballed engines and aerodynamic control surfaces.
  * Returns the torques in <math>N.m</math> around each of the coordinate axes of the
  * vessels reference frame ({@link T:SpaceCenter.ReferenceFrame}).
  * These axes are equivalent to the pitch, roll and yaw axes of the vessel.
@@ -13678,7 +17526,8 @@ module.exports.vesselGetAvailableControlSurfaceTorque = function vesselGetAvaila
 
 /**
  * @augments SpaceCenter
- * @description The maximum torque that parts (excluding reaction wheels, gimballed engines, RCS and control surfaces) can generate.
+ * @description The maximum torque that parts (excluding reaction wheels, gimballed engines,
+ * RCS and control surfaces) can generate.
  * Returns the torques in <math>N.m</math> around each of the coordinate axes of the
  * vessels reference frame ({@link T:SpaceCenter.ReferenceFrame}).
  * These axes are equivalent to the pitch, roll and yaw axes of the vessel.
@@ -13721,7 +17570,8 @@ module.exports.vesselGetAvailableOtherTorque = function vesselGetAvailableOtherT
 
 /**
  * @augments SpaceCenter
- * @description The reference frame that is fixed relative to the vessel, and orientated with the vessel.
+ * @description The reference frame that is fixed relative to the vessel,
+ * and orientated with the vessel.
  * <list type="bullet"><item><description>The origin is at the center of mass of the vessel.</description></item><item><description>The axes rotate with the vessel.</description></item><item><description>The x-axis points out to the right of the vessel.</description></item><item><description>The y-axis points in the forward direction of the vessel.</description></item><item><description>The z-axis points out of the bottom off the vessel.</description></item></list>
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
  * @result {Long} A long value representing the id for the SpaceCenter.ReferenceFrame
@@ -13739,8 +17589,8 @@ module.exports.vesselGetReferenceFrame = function vesselGetReferenceFrame(vessel
 
 /**
  * @augments SpaceCenter
- * @description The reference frame that is fixed relative to the vessel, and orientated with the vessels
- * orbital prograde/normal/radial directions.
+ * @description The reference frame that is fixed relative to the vessel,
+ * and orientated with the vessels orbital prograde/normal/radial directions.
  * <list type="bullet"><item><description>The origin is at the center of mass of the vessel.</description></item><item><description>The axes rotate with the orbital prograde/normal/radial directions.</description></item><item><description>The x-axis points in the orbital anti-radial direction.</description></item><item><description>The y-axis points in the orbital prograde direction.</description></item><item><description>The z-axis points in the orbital normal direction.</description></item></list><remarks>
  * Be careful not to confuse this with 'orbit' mode on the navball.
  * @param {Long} vessel - A long value representing the id for the SpaceCenter.Vessel
@@ -13759,8 +17609,8 @@ module.exports.vesselGetOrbitalReferenceFrame = function vesselGetOrbitalReferen
 
 /**
  * @augments SpaceCenter
- * @description The reference frame that is fixed relative to the vessel, and orientated with the surface
- * of the body being orbited.
+ * @description The reference frame that is fixed relative to the vessel,
+ * and orientated with the surface of the body being orbited.
  * <list type="bullet"><item><description>The origin is at the center of mass of the vessel.</description></item><item><description>The axes rotate with the north and up directions on the surface of the body.</description></item><item><description>The x-axis points in the <a href="https://en.wikipedia.org/wiki/Zenith">zenith</a>
  * direction (upwards, normal to the body being orbited, from the center of the body towards the center of
  * mass of the vessel).</description></item><item><description>The y-axis points northwards towards the
@@ -13785,8 +17635,9 @@ module.exports.vesselGetSurfaceReferenceFrame = function vesselGetSurfaceReferen
 
 /**
  * @augments SpaceCenter
- * @description The reference frame that is fixed relative to the vessel, and orientated with the velocity
- * vector of the vessel relative to the surface of the body being orbited.
+ * @description The reference frame that is fixed relative to the vessel,
+ * and orientated with the velocity vector of the vessel relative
+ * to the surface of the body being orbited.
  * <list type="bullet"><item><description>The origin is at the center of mass of the vessel.</description></item><item><description>The axes rotate with the vessel's velocity vector.</description></item><item><description>The y-axis points in the direction of the vessel's velocity vector,
  * relative to the surface of the body being orbited.</description></item><item><description>The z-axis is in the plane of the
  * <a href="https://en.wikipedia.org/wiki/Horizon">astronomical horizon</a>.</description></item><item><description>The x-axis is orthogonal to the other two axes.</description></item></list>
@@ -13823,7 +17674,7 @@ module.exports.waypointRemove = function waypointRemove(waypoint) {
 
 /**
  * @augments SpaceCenter
- * @description Celestial body the waypoint is attached to.
+ * @description The celestial body the waypoint is attached to.
  * @param {Long} waypoint - A long value representing the id for the SpaceCenter.Waypoint
  * @result {Long} A long value representing the id for the SpaceCenter.CelestialBody
  * @returns {{call :Object, decode: function}}
@@ -13840,7 +17691,7 @@ module.exports.waypointGetBody = function waypointGetBody(waypoint) {
 
 /**
  * @augments SpaceCenter
- * @description Celestial body the waypoint is attached to.
+ * @description The celestial body the waypoint is attached to.
  * @param {Long} waypoint - A long value representing the id for the SpaceCenter.Waypoint
  * @param {Long} value - A long value representing the id for the SpaceCenter.CelestialBody
  * @result {void}
@@ -13859,7 +17710,7 @@ module.exports.waypointSetBody = function waypointSetBody(waypoint, value) {
 
 /**
  * @augments SpaceCenter
- * @description Name of the waypoint as it appears on the map and the contract.
+ * @description The name of the waypoint as it appears on the map and the contract.
  * @param {Long} waypoint - A long value representing the id for the SpaceCenter.Waypoint
  * @result {string}
  * @returns {{call :Object, decode: function}}
@@ -13876,7 +17727,7 @@ module.exports.waypointGetName = function waypointGetName(waypoint) {
 
 /**
  * @augments SpaceCenter
- * @description Name of the waypoint as it appears on the map and the contract.
+ * @description The name of the waypoint as it appears on the map and the contract.
  * @param {Long} waypoint - A long value representing the id for the SpaceCenter.Waypoint
  * @param {string} value
  * @result {void}
@@ -14075,7 +17926,8 @@ module.exports.waypointSetMeanAltitude = function waypointSetMeanAltitude(waypoi
 
 /**
  * @augments SpaceCenter
- * @description The altitude of the waypoint above the surface of the body or sea level, whichever is closer, in meters.
+ * @description The altitude of the waypoint above the surface of the body or sea level,
+ * whichever is closer, in meters.
  * @param {Long} waypoint - A long value representing the id for the SpaceCenter.Waypoint
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -14092,7 +17944,8 @@ module.exports.waypointGetSurfaceAltitude = function waypointGetSurfaceAltitude(
 
 /**
  * @augments SpaceCenter
- * @description The altitude of the waypoint above the surface of the body or sea level, whichever is closer, in meters.
+ * @description The altitude of the waypoint above the surface of the body or sea level,
+ * whichever is closer, in meters.
  * @param {Long} waypoint - A long value representing the id for the SpaceCenter.Waypoint
  * @param {number} value
  * @result {void}
@@ -14111,7 +17964,8 @@ module.exports.waypointSetSurfaceAltitude = function waypointSetSurfaceAltitude(
 
 /**
  * @augments SpaceCenter
- * @description The altitude of the waypoint above the surface of the body, in meters. When over water, this is the altitude above the sea floor.
+ * @description The altitude of the waypoint above the surface of the body, in meters.
+ * When over water, this is the altitude above the sea floor.
  * @param {Long} waypoint - A long value representing the id for the SpaceCenter.Waypoint
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -14128,7 +17982,8 @@ module.exports.waypointGetBedrockAltitude = function waypointGetBedrockAltitude(
 
 /**
  * @augments SpaceCenter
- * @description The altitude of the waypoint above the surface of the body, in meters. When over water, this is the altitude above the sea floor.
+ * @description The altitude of the waypoint above the surface of the body, in meters.
+ * When over water, this is the altitude above the sea floor.
  * @param {Long} waypoint - A long value representing the id for the SpaceCenter.Waypoint
  * @param {number} value
  * @result {void}
@@ -14147,7 +18002,7 @@ module.exports.waypointSetBedrockAltitude = function waypointSetBedrockAltitude(
 
 /**
  * @augments SpaceCenter
- * @description True if waypoint is a point near or on the body rather than high in orbit.
+ * @description <summary>true if the waypoint is near to the surface of a body.
  * @param {Long} waypoint - A long value representing the id for the SpaceCenter.Waypoint
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
@@ -14164,7 +18019,7 @@ module.exports.waypointGetNearSurface = function waypointGetNearSurface(waypoint
 
 /**
  * @augments SpaceCenter
- * @description True if waypoint is actually glued to the ground.
+ * @description <summary>true if the waypoint is attached to the ground.
  * @param {Long} waypoint - A long value representing the id for the SpaceCenter.Waypoint
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
@@ -14181,10 +18036,11 @@ module.exports.waypointGetGrounded = function waypointGetGrounded(waypoint) {
 
 /**
  * @augments SpaceCenter
- * @description The integer index of this waypoint amongst its cluster of sibling waypoints.
- * In other words, when you have a cluster of waypoints called "Somewhere Alpha", "Somewhere Beta", and "Somewhere Gamma",
- * then the alpha site has index 0, the beta site has index 1 and the gamma site has index 2.
- * When {@link M:SpaceCenter.Waypoint.Clustered} is false, this value is zero but meaningless.
+ * @description The integer index of this waypoint within its cluster of sibling waypoints.
+ * In other words, when you have a cluster of waypoints called "Somewhere Alpha",
+ * "Somewhere Beta" and "Somewhere Gamma", the alpha site has index 0, the beta
+ * site has index 1 and the gamma site has index 2.
+ * When {@link M:SpaceCenter.Waypoint.Clustered} is false, this is zero.
  * @param {Long} waypoint - A long value representing the id for the SpaceCenter.Waypoint
  * @result {number}
  * @returns {{call :Object, decode: function}}
@@ -14201,8 +18057,10 @@ module.exports.waypointGetIndex = function waypointGetIndex(waypoint) {
 
 /**
  * @augments SpaceCenter
- * @description True if this waypoint is part of a set of clustered waypoints with greek letter names appended (Alpha, Beta, Gamma, etc).
- * If true, there is a one-to-one correspondence with the greek letter name and the {@link M:SpaceCenter.Waypoint.Index}.
+ * @description <summary>true if this waypoint is part of a set of clustered waypoints with greek letter
+ * names appended (Alpha, Beta, Gamma, etc).
+ * If true, there is a one-to-one correspondence with the greek letter name and
+ * the {@link M:SpaceCenter.Waypoint.Index}.
  * @param {Long} waypoint - A long value representing the id for the SpaceCenter.Waypoint
  * @result {boolean}
  * @returns {{call :Object, decode: function}}
@@ -14236,19 +18094,18 @@ module.exports.waypointGetHasContract = function waypointGetHasContract(waypoint
 
 /**
  * @augments SpaceCenter
- * @description The id of the associated contract.
- * Returns 0 if the waypoint does not belong to a contract.
+ * @description The associated contract.
  * @param {Long} waypoint - A long value representing the id for the SpaceCenter.Waypoint
- * @result {number}
+ * @result {Long} A long value representing the id for the SpaceCenter.Contract
  * @returns {{call :Object, decode: function}}
  */
-module.exports.waypointGetContractId = function waypointGetContractId(waypoint) {
+module.exports.waypointGetContract = function waypointGetContract(waypoint) {
     let encodedArguments = [
         encoders.uInt64(waypoint)
     ];
     return {
-        call: buildProcedureCall('SpaceCenter', 'Waypoint_get_ContractId', encodedArguments),
-        decode: decoders.sInt64
+        call: buildProcedureCall('SpaceCenter', 'Waypoint_get_Contract', encodedArguments),
+        decode: decoders.uInt64
     };
 };
 
@@ -14256,11 +18113,11 @@ module.exports.waypointGetContractId = function waypointGetContractId(waypoint) 
  * @augments SpaceCenter
  * @description Creates a waypoint at the given position at ground level, and returns a
  * {@link T:SpaceCenter.Waypoint} object that can be used to modify it.
- *
- *
- *
- *
- * <returns></returns>
+ * 
+ * 
+ * 
+ * 
+ * Returns:
  * @param {Long} waypointManager - A long value representing the id for the SpaceCenter.WaypointManager
  * @param {number} latitude - Latitude of the waypoint.
  * @param {number} longitude - Longitude of the waypoint.
@@ -14279,6 +18136,40 @@ module.exports.waypointManagerAddWaypoint = function waypointManagerAddWaypoint(
     ];
     return {
         call: buildProcedureCall('SpaceCenter', 'WaypointManager_AddWaypoint', encodedArguments),
+        decode: decoders.uInt64
+    };
+};
+
+/**
+ * @augments SpaceCenter
+ * @description Creates a waypoint at the given position and altitude, and returns a
+ * {@link T:SpaceCenter.Waypoint} object that can be used to modify it.
+ * 
+ * 
+ * 
+ * 
+ * 
+ * Returns:
+ * @param {Long} waypointManager - A long value representing the id for the SpaceCenter.WaypointManager
+ * @param {number} latitude - Latitude of the waypoint.
+ * @param {number} longitude - Longitude of the waypoint.
+ * @param {number} altitude - Altitude (above sea level) of the waypoint.
+ * @param {Long} body - A long value representing the id for the SpaceCenter.CelestialBody
+ * @param {string} name - Name of the waypoint.
+ * @result {Long} A long value representing the id for the SpaceCenter.Waypoint
+ * @returns {{call :Object, decode: function}}
+ */
+module.exports.waypointManagerAddWaypointAtAltitude = function waypointManagerAddWaypointAtAltitude(waypointManager, latitude, longitude, altitude, body, name) {
+    let encodedArguments = [
+        encoders.uInt64(waypointManager),
+        encoders.double(latitude),
+        encoders.double(longitude),
+        encoders.double(altitude),
+        encoders.uInt64(body),
+        encoders.string(name)
+    ];
+    return {
+        call: buildProcedureCall('SpaceCenter', 'WaypointManager_AddWaypointAtAltitude', encodedArguments),
         decode: decoders.uInt64
     };
 };

--- a/test/api/stream/stream-throttle-callbacks.integration.js
+++ b/test/api/stream/stream-throttle-callbacks.integration.js
@@ -106,8 +106,8 @@ function addThrottleToStream(data, callback) {
 
 function addHeadingToStream(data, callback) {
     let getHeading = data.client.services.spaceCenter.flightGetHeading(data.vessel.flightId);
-    data.client.addStream(getHeading, "Heading", throttleStreamAdded);
-    function throttleStreamAdded(err) {
+    data.client.addStream(getHeading, "Heading", headingStreamAdded);
+    function headingStreamAdded(err) {
         data.client.stream.on('message', streamUpdate(data));
         return callback(err, data);
     }

--- a/test/api/stream/stream-throttle-callbacks.integration.js
+++ b/test/api/stream/stream-throttle-callbacks.integration.js
@@ -118,7 +118,7 @@ function streamUpdate(data) {
     return function _streamUpdate(streamState) {
         console.log(streamState);
         counter++;
-        if (counter > 50) {
+        if (counter === 50) {
             data.done();
         }
     };

--- a/test/api/stream/stream-throttle-events.integration.js
+++ b/test/api/stream/stream-throttle-events.integration.js
@@ -143,7 +143,7 @@ function streamUpdate(streamState, streamUpdateResponse) {
         let parsedValue = stream.decode(update.result.value);
         console.log(stream.name, ' : ', parsedValue);
         counter++;
-        if (counter > 50) {
+        if (counter === 50) {
             done();
         }
     });

--- a/test/api/stream/stream-throttle-events.integration.js
+++ b/test/api/stream/stream-throttle-events.integration.js
@@ -136,7 +136,7 @@ function streamUpdate(streamState, streamUpdateResponse) {
             console.error(update.result.error);
             return;
         }
-        let stream = game.streams[update.id.toString()];
+        let stream = game.streams && game.streams[update.id.toString()];
         if (!stream) {
             return;
         }

--- a/test/api/stream/stream-throttle-events.integration.js
+++ b/test/api/stream/stream-throttle-events.integration.js
@@ -103,7 +103,7 @@ function getVesselFlightComplete(getVesselResponse) {
         id: getFirstResult(getVesselResponse)
     };
     let getThrottle = client.services.spaceCenter.controlGetThrottle(game.vessel.control.id);
-    let addStreamCall = client.services.krpc.addStream(getThrottle.call);
+    let addStreamCall = client.services.krpc.addStream(getThrottle.call, true);
     client.send(addStreamCall);
     replaceMessageHandler(throttleStreamAdded);
     client.stream.on('message', streamUpdate);
@@ -115,7 +115,7 @@ function getVesselFlightComplete(getVesselResponse) {
             decode: getThrottle.decode
         };
         let getHeading = client.services.spaceCenter.flightGetHeading(game.vessel.flight.id);
-        addStreamCall = client.services.krpc.addStream(getHeading.call);
+        addStreamCall = client.services.krpc.addStream(getHeading.call, true);
         client.send(addStreamCall);
         replaceMessageHandler(headingStreamAdded);
 

--- a/utilities/generate-services.js
+++ b/utilities/generate-services.js
@@ -95,6 +95,12 @@ function processDocumentation(procedureOrService, isService, serviceName) {
         .replace(/<\/summary>\s/g, '')
         .replace(/\s<remarks>\s/g, '\n ')
         .replace(/<\/remarks>\s/g, '')
+        .replace(/\s<returns>/g, '\nReturns: ')
+        .replace(/<\/returns>/g, '')
+        .replace(/<paramref name="/g, '{')
+        .replace(/<\/paramref>/g, '')
+        .replace(/<c>/g, '')
+        .replace(/<\/c>/g, '')
         .replace(/<param.*<\/param>/g, '')
         .replace(/<see cref="/g, '{@link ')
         .replace(/" \/>/g, '}');

--- a/utilities/generate-services.js
+++ b/utilities/generate-services.js
@@ -225,6 +225,10 @@ function getParamName(param) {
     if (name === 'this') {
         name = _.camelCase(param.type.name);
     }
+    // TODO: check for other reserved keywords too
+    if (name === 'function') {
+        name += '_';
+    }
     if (!name) {
         throw new Error('Name was null');
     }

--- a/utilities/generate-services.js
+++ b/utilities/generate-services.js
@@ -175,8 +175,8 @@ const typeCodeMappings = {
     100: {originalName: 'CLASS', dotNet: 'Class', jsDoc: 'Object'},
     101: {originalName: 'ENUMERATION', dotNet: 'Enumeration', jsDoc: 'Object'},
     //  Messages
-    200: {originalName: 'REQUEST', dotNet: 'Request', jsDoc: 'Object'},
-    201: {originalName: 'STREAM_UPDATE', dotNet: 'StreamUpdate', jsDoc: 'Object'},
+    200: {originalName: 'EVENT', dotNet: 'Event', jsDoc: 'Object'},
+    201: {originalName: 'PROCEDURE_CALL', dotNet: 'ProcedureCall', jsDoc: 'Object'},
     202: {originalName: 'STREAM', dotNet: 'Stream', jsDoc: 'Object'},
     203: {originalName: 'STATUS', dotNet: 'Status', jsDoc: 'Object'},
     204: {originalName: 'SERVICES', dotNet: 'Services', jsDoc: 'Object'},
@@ -203,6 +203,7 @@ function getTypeStringFromCode(type, doNotAddBraces, param) {
         case 201:
         case 202:
         case 203:
+        case 204:
             return processValueType(type, doNotAddBraces, param);
         case 100:
         case 101:
@@ -360,12 +361,14 @@ function getDecoder(type, depth = 1) {
         case 101:
             return getEnumFunction(decodersName, type);
         case 200:
-            return 'proto.ProcedureCall';
+            return 'proto.Event';
         case 201:
-            return 'proto.Stream';
+            return 'proto.ProcedureCall';
         case 202:
-            return 'proto.Status';
+            return 'proto.Stream';
         case 203:
+            return 'proto.Status';
+        case 204:
             return 'proto.Services';
         case 300:
             return getDecodeFnSubType('proto.Tuple', type, depth);
@@ -456,18 +459,22 @@ function getEncodeFnForParam(service, parameter) {
             content += getEnumFunction(encodersName, parameter.type);
             break;
         case 200:
-            content += '{buffer: proto.ProcedureCall.encode';
+            content += '{buffer: proto.Event.encode';
             addDotFinish = true;
             break;
         case 201:
-            content += '{buffer: proto.Stream.encode';
+            content += '{buffer: proto.ProcedureCall.encode';
             addDotFinish = true;
             break;
         case 202:
-            content += '{buffer: proto.Status.encode';
+            content += '{buffer: proto.Stream.encode';
             addDotFinish = true;
             break;
         case 203:
+            content += '{buffer: proto.Status.encode';
+            addDotFinish = true;
+            break;
+        case 204:
             content += '{buffer: proto.Services.encode';
             addDotFinish = true;
             break;

--- a/utilities/generate-services.js
+++ b/utilities/generate-services.js
@@ -387,25 +387,25 @@ function getDecoder(type, depth = 1) {
     }
 }
 
-function getDecodeFnSubType(decodeTypeString, type, depth = 1) {
-    depth++;
+function getDecodeFnSubType(decodeTypeString, type, depth = 0) {
     if (depth > 5) {
         throw new Error(util.format('Maximum depth exceeded', decodeTypeString, type, depth));
     }
+    var indent = new Array(depth*8+1).join(' ');
     let result = '{' + eol;
-    result += '            isCollection: true,' + eol;
-    result += '            decode: ' + decodeTypeString + ',' + eol;
-    result += '            subTypes: [' + eol;
+    result += indent + '    isCollection: true,' + eol;
+    result += indent + '    decode: ' + decodeTypeString + ',' + eol;
+    result += indent + '    subTypes: [' + eol;
     for (let i = 0; i < type.types.length; i++) {
         let subType = type.types[i];
-        result += '                ' + getDecoder(subType, depth);
+        result += indent + '        ' + getDecoder(subType, depth+1);
         if (i < type.types.length - 1) {
             result += ',';
         }
         result += eol;
     }
-    result += '            ]' + eol;
-    result += '        }';
+    result += indent + '    ]' + eol;
+    result += indent + '}';
     return result;
 }
 


### PR DESCRIPTION
This PR includes changes to update the client to work with the new features in server version 0.4.4.

Changes include:
 * Updates to protobuf schema
 * Regenerated the service specific code against server v0.4.4
 * Regenerated the documentation
 * Added second argument to KRPC.AddStream
 * Fixed some issues in the stream unit tests 

One thing that is new in v0.4.4 that isn't supported by the client (and I haven't added in this PR) is the ability to wait on events. For example, in the python client: http://krpc.github.io/krpc/python/client.html#custom-events