### PR TITLE
Fixing an encodeEnum bug

### DIFF
--- a/lib/encoders.js
+++ b/lib/encoders.js
@@ -148,7 +148,7 @@ function encodeEnum(enumDefinition) {
             }
             return false;
         });
-        if (!foundEnumVal) {
+        if (!Number.isInteger(foundEnumVal)) {
             throw Error(
                 `Invalid enum value ${value}, should have been one of ${JSON.stringify(
                     enumDefinition


### PR DESCRIPTION
I was trying to call (not send even, just call) `spaceCenter.autoPilotSetSasMode(autoPilot, 'StabilityAssist')`, but it threw. It seems that the `encodeValueBasedOnEnum `function will throw if the passed value is the 0th enum value. In this scenario, `foundEnumVal === 0`, yet that triggers the throw.

An alternate solution would be to set `foundEnumVal = null` and check for `null `instead of using `Number.isInteger`.