### PR TITLE
Call `buffer.readIntLE` with arguments

### DIFF
--- a/lib/decoders.js
+++ b/lib/decoders.js
@@ -64,7 +64,7 @@ function decodeUInt32(buffer) {
  * @return {*}
  */
 function decodeUInt64(buffer) {
-    return buffer.readIntLE();
+    return buffer.readIntLE(0, 1);
 }
 
 /**
@@ -73,7 +73,7 @@ function decodeUInt64(buffer) {
  * @return {boolean}
  */
 function decodeBool(buffer) {
-    let numericalValue = buffer.readIntLE();
+    let numericalValue = buffer.readIntLE(0, 1);
     return Boolean(numericalValue);
 }
 


### PR DESCRIPTION
Node's [buffer.readIntLE](https://nodejs.org/api/buffer.html#buffer_buf_readintle_offset_bytelength) is documented as having two required arguments, offset and bytelength. This file calls the method several times with no arguments. This was causing issues for me on mac, node v12.4.0. I modified these two calls to pass those arguments, which I found through trial and error. I don't understand what they do. That was enough to get my specific program running. This PR is not a fix - it's an explanation of what I think might be causing issue #16. Hopefully it's useful for you or someone in finding and fixing the issue.

Thanks for an awesome library, I have been having great fun crashing lots of spacecraft.